### PR TITLE
libvirt: add --bind-storage-ro support for bootc upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "serde_yaml",
  "shlex",
  "similar-asserts",
  "strum",
@@ -2026,6 +2027,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2501,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -204,6 +204,10 @@ fn main() {
             tests::libvirt_verb::test_libvirt_error_handling();
             Ok(())
         }),
+        Trial::test("libvirt_bind_storage_ro", || {
+            tests::libvirt_verb::test_libvirt_bind_storage_ro();
+            Ok(())
+        }),
     ];
 
     // Run the tests and exit with the result

--- a/crates/integration-tests/src/tests/libvirt_verb.rs
+++ b/crates/integration-tests/src/tests/libvirt_verb.rs
@@ -382,6 +382,58 @@ fn cleanup_domain(domain_name: &str) {
     }
 }
 
+/// Wait for SSH to become available on a domain with a timeout
+fn wait_for_ssh_available(
+    bck: &str,
+    domain_name: &str,
+    timeout_secs: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start_time = std::time::Instant::now();
+    let timeout_duration = std::time::Duration::from_secs(timeout_secs);
+
+    println!(
+        "Waiting for SSH to become available on domain: {}",
+        domain_name
+    );
+
+    loop {
+        // Try a simple SSH command to test connectivity
+        let ssh_test = Command::new("timeout")
+            .args([
+                "10s", // Short timeout for individual SSH attempts
+                bck,
+                "libvirt",
+                "ssh",
+                domain_name,
+                "--",
+                "echo",
+                "ssh-ready",
+            ])
+            .output();
+
+        match ssh_test {
+            Ok(output) if output.status.success() => {
+                println!("✓ SSH is now available");
+                return Ok(());
+            }
+            Ok(_) => {
+                // SSH command failed, but that's expected while VM is booting
+            }
+            Err(e) => {
+                println!("SSH test error (expected while booting): {}", e);
+            }
+        }
+
+        // Check if we've exceeded the timeout
+        if start_time.elapsed() >= timeout_duration {
+            return Err(format!("Timeout waiting for SSH after {} seconds", timeout_secs).into());
+        }
+
+        // Wait 5 seconds before next attempt
+        std::thread::sleep(std::time::Duration::from_secs(5));
+    }
+}
+
 /// Test VM startup and shutdown with libvirt run
 pub fn test_libvirt_vm_lifecycle() {
     // Skip if running in CI/container environment without libvirt
@@ -509,6 +561,239 @@ pub fn test_libvirt_vm_lifecycle() {
     }
 
     println!("VM lifecycle test completed");
+}
+
+/// Test container storage binding functionality end-to-end
+pub fn test_libvirt_bind_storage_ro() {
+    let bck = get_bck_command().unwrap();
+    let test_image = get_test_image();
+
+    // First check if libvirt supports readonly virtiofs
+    println!("Checking libvirt capabilities...");
+    let status_output = Command::new(&bck)
+        .args(&["libvirt", "status", "--format", "json"])
+        .output()
+        .expect("Failed to get libvirt status");
+
+    if !status_output.status.success() {
+        let stderr = String::from_utf8_lossy(&status_output.stderr);
+        panic!("Failed to get libvirt status: {}", stderr);
+    }
+
+    let status: serde_json::Value =
+        serde_json::from_slice(&status_output.stdout).expect("Failed to parse libvirt status JSON");
+
+    let supports_readonly = status["supports_readonly_virtiofs"]
+        .as_bool()
+        .expect("Missing supports_readonly_virtiofs field in status output");
+
+    if !supports_readonly {
+        println!("Skipping test: libvirt does not support readonly virtiofs");
+        println!("libvirt version: {:?}", status["version"]);
+        println!("Requires libvirt 11.0+ for readonly virtiofs support");
+        return;
+    }
+
+    // Generate unique domain name for this test
+    let domain_name = format!(
+        "test-bind-storage-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+
+    println!("Testing --bind-storage-ro with domain: {}", domain_name);
+
+    // Cleanup any existing domain with this name
+    let _ = Command::new("virsh")
+        .args(&["destroy", &domain_name])
+        .output();
+    let _ = Command::new("virsh")
+        .args(&["undefine", &domain_name])
+        .output();
+
+    // Create domain with --bind-storage-ro flag
+    println!("Creating libvirt domain with --bind-storage-ro...");
+    let create_output = Command::new("timeout")
+        .args([
+            "300s", // 5 minute timeout for domain creation
+            &bck,
+            "libvirt",
+            "run",
+            "--name",
+            &domain_name,
+            "--bind-storage-ro",
+            "--filesystem",
+            "ext4",
+            &test_image,
+        ])
+        .output()
+        .expect("Failed to run libvirt run with --bind-storage-ro");
+
+    let create_stdout = String::from_utf8_lossy(&create_output.stdout);
+    let create_stderr = String::from_utf8_lossy(&create_output.stderr);
+
+    println!("Create stdout: {}", create_stdout);
+    println!("Create stderr: {}", create_stderr);
+
+    if !create_output.status.success() {
+        cleanup_domain(&domain_name);
+        panic!(
+            "Failed to create domain with --bind-storage-ro: {}",
+            create_stderr
+        );
+    }
+
+    println!("Successfully created domain: {}", domain_name);
+
+    // Check that the domain was created with virtiofs filesystem
+    println!("Checking domain XML for virtiofs filesystem...");
+    let dumpxml_output = Command::new("virsh")
+        .args(&["dumpxml", &domain_name])
+        .output()
+        .expect("Failed to dump domain XML");
+
+    if !dumpxml_output.status.success() {
+        cleanup_domain(&domain_name);
+        let stderr = String::from_utf8_lossy(&dumpxml_output.stderr);
+        panic!("Failed to dump domain XML: {}", stderr);
+    }
+
+    let domain_xml = String::from_utf8_lossy(&dumpxml_output.stdout);
+    println!(
+        "Domain XML snippet: {}",
+        &domain_xml[..std::cmp::min(500, domain_xml.len())]
+    );
+
+    // Verify that the domain XML contains virtiofs configuration
+    assert!(
+        domain_xml.contains("type='virtiofs'") || domain_xml.contains("driver type='virtiofs'"),
+        "Domain XML should contain virtiofs filesystem configuration"
+    );
+
+    // Verify that the filesystem has the correct tag
+    assert!(
+        domain_xml.contains("hoststorage") || domain_xml.contains("dir='hoststorage'"),
+        "Domain XML should reference the hoststorage tag for container storage"
+    );
+
+    // Verify that the domain XML contains readonly element for virtiofs
+    assert!(
+        domain_xml.contains("<readonly/>"),
+        "Domain XML should contain readonly element for --bind-storage-ro"
+    );
+
+    // Check metadata for bind-storage-ro configuration
+    if domain_xml.contains("bootc:bind-storage-ro") {
+        assert!(
+            domain_xml.contains("<bootc:bind-storage-ro>true</bootc:bind-storage-ro>"),
+            "Domain metadata should indicate bind-storage-ro is enabled"
+        );
+    }
+
+    println!("✓ Domain XML contains expected virtiofs configuration");
+    println!("✓ Container storage mount is configured as read-only");
+    println!("✓ hoststorage tag is present in filesystem configuration");
+
+    // Wait for VM to boot and SSH to become available
+    if let Err(e) = wait_for_ssh_available(&bck, &domain_name, 180) {
+        cleanup_domain(&domain_name);
+        panic!("Failed to establish SSH connection: {}", e);
+    }
+
+    // Create mount point and mount virtiofs filesystem
+    println!("Creating mount point and mounting virtiofs filesystem...");
+    let mount_setup = Command::new("timeout")
+        .args([
+            "30s",
+            &bck,
+            "libvirt",
+            "ssh",
+            &domain_name,
+            "--",
+            "sudo",
+            "mkdir",
+            "-p",
+            "/run/virtiofs-mnt-hoststorage",
+        ])
+        .output()
+        .expect("Failed to create mount point");
+
+    if !mount_setup.status.success() {
+        let stderr = String::from_utf8_lossy(&mount_setup.stderr);
+        println!("Warning: Failed to create mount point: {}", stderr);
+    }
+
+    let mount_cmd = Command::new("timeout")
+        .args([
+            "30s",
+            &bck,
+            "libvirt",
+            "ssh",
+            &domain_name,
+            "--",
+            "sudo",
+            "mount",
+            "-t",
+            "virtiofs",
+            "hoststorage",
+            "/run/virtiofs-mnt-hoststorage",
+        ])
+        .output()
+        .expect("Failed to mount virtiofs");
+
+    if !mount_cmd.status.success() {
+        cleanup_domain(&domain_name);
+        let stderr = String::from_utf8_lossy(&mount_cmd.stderr);
+        panic!("Failed to mount virtiofs filesystem: {}", stderr);
+    }
+
+    // Test SSH connection and verify container storage mount inside VM
+    println!("Testing SSH connection and checking container storage mount...");
+    let st = Command::new("timeout")
+        .args([
+            "60s",
+            &bck,
+            "libvirt",
+            "ssh",
+            &domain_name,
+            "--",
+            "ls",
+            "-la",
+            "/run/virtiofs-mnt-hoststorage/overlay",
+        ])
+        .status()
+        .expect("Failed to run SSH command to check container storage");
+
+    assert!(st.success());
+
+    // Verify that the mount is read-only
+    println!("Verifying that the mount is read-only...");
+    let ro_test_st = Command::new("timeout")
+        .args([
+            "30s",
+            &bck,
+            "libvirt",
+            "ssh",
+            &domain_name,
+            "--",
+            "touch",
+            "/run/virtiofs-mnt-hoststorage/test-write",
+        ])
+        .status()
+        .expect("Failed to run SSH command to test read-only mount");
+
+    assert!(
+        !ro_test_st.success(),
+        "Mount should be read-only, but write operation succeeded"
+    );
+    println!("✓ Mount is correctly configured as read-only.");
+
+    // Cleanup domain before completing test
+    cleanup_domain(&domain_name);
+
+    println!("✓ --bind-storage-ro end-to-end test passed");
 }
 
 /// Test error handling for invalid configurations

--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0"
 rustix = { "version" = "1", features = ["thread", "net", "fs", "pipe", "system", "process", "mount"] }
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
+serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/kit/src/libvirt/mod.rs
+++ b/crates/kit/src/libvirt/mod.rs
@@ -19,6 +19,7 @@ pub mod rm;
 pub mod run;
 pub mod ssh;
 pub mod start;
+pub mod status;
 pub mod stop;
 pub mod upload;
 
@@ -51,6 +52,9 @@ pub enum LibvirtCommands {
     /// Show detailed information about a libvirt domain
     Inspect(inspect::LibvirtInspectOpts),
 
+    /// Show libvirt environment status and capabilities
+    Status(status::LibvirtStatusOpts),
+
     /// Upload bootc disk images to libvirt with metadata annotations
     Upload(upload::LibvirtUploadOpts),
 
@@ -69,6 +73,7 @@ impl LibvirtCommands {
             LibvirtCommands::Start(opts) => start::run(opts),
             LibvirtCommands::Remove(opts) => rm::run(opts),
             LibvirtCommands::Inspect(opts) => inspect::run(opts),
+            LibvirtCommands::Status(opts) => status::run(opts),
             LibvirtCommands::Upload(opts) => upload::run(opts),
             LibvirtCommands::Create(opts) => create::run(opts),
         }

--- a/crates/kit/src/libvirt/status.rs
+++ b/crates/kit/src/libvirt/status.rs
@@ -1,0 +1,278 @@
+//! libvirt status command - show libvirt environment information
+//!
+//! This module provides a status command that outputs JSON metadata about
+//! the libvirt environment, including version information and domain count.
+
+use clap::Parser;
+use color_eyre::{eyre::Context, Result};
+use serde::{Deserialize, Serialize};
+use std::process::Command;
+
+use crate::domain_list::DomainLister;
+
+/// Options for the libvirt status command
+#[derive(Debug, Parser)]
+pub struct LibvirtStatusOpts {
+    /// Output format (yaml or json)
+    #[clap(long, default_value = "yaml", value_enum)]
+    pub format: OutputFormat,
+}
+
+/// Output format for status command
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum OutputFormat {
+    /// YAML format (default, human-readable)
+    Yaml,
+    /// JSON format (machine-readable)
+    Json,
+}
+
+/// libvirt version information
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LibvirtVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub micro: u32,
+    pub full_version: String,
+}
+
+/// libvirt status information
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LibvirtStatus {
+    pub version: Option<LibvirtVersion>,
+    pub supports_readonly_virtiofs: bool,
+    pub domain_count: usize,
+    pub running_domain_count: usize,
+}
+
+/// Parse a version string like "6.2.0" into LibvirtVersion struct
+fn parse_version_string(version_str: &str) -> Option<LibvirtVersion> {
+    let parts: Vec<&str> = version_str.split('.').collect();
+    if parts.is_empty() {
+        return None;
+    }
+
+    let major = parts[0].parse::<u32>().ok()?;
+    let minor = if parts.len() > 1 {
+        parts[1].parse::<u32>().unwrap_or(0)
+    } else {
+        0
+    };
+    let micro = if parts.len() > 2 {
+        parts[2].parse::<u32>().unwrap_or(0)
+    } else {
+        0
+    };
+
+    Some(LibvirtVersion {
+        major,
+        minor,
+        micro,
+        full_version: version_str.to_string(),
+    })
+}
+
+/// Parse libvirt version from virsh version output text
+fn parse_libvirt_version_from_output(version_output: &str) -> Option<LibvirtVersion> {
+    // Parse version from output like "Compiled against library: libvirt 6.2.0"
+    // or "Using library: libvirt 6.2.0"
+    for line in version_output.lines() {
+        if line.contains("libvirt") {
+            // Find "libvirt X.Y.Z" pattern
+            if let Some(version_part) = line.strip_prefix("libvirt ").or_else(|| {
+                line.find("libvirt ")
+                    .and_then(|start| line[start..].strip_prefix("libvirt "))
+            }) {
+                let version_end = version_part.find(' ').unwrap_or(version_part.len());
+                let version_str = &version_part[..version_end];
+
+                if let Some(version) = parse_version_string(version_str) {
+                    return Some(version);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse libvirt version from virsh version output
+pub fn parse_libvirt_version() -> Result<Option<LibvirtVersion>> {
+    let output = Command::new("virsh")
+        .args(&["version"])
+        .output()
+        .with_context(|| "Failed to check libvirt version")?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let version_output = String::from_utf8(output.stdout)
+        .with_context(|| "virsh version output contained invalid UTF-8")?;
+
+    Ok(parse_libvirt_version_from_output(&version_output))
+}
+
+/// Check if libvirt supports readonly virtiofs
+pub fn supports_readonly_virtiofs(version: &Option<LibvirtVersion>) -> bool {
+    match version {
+        Some(v) => {
+            // Requires libvirt 11.0+ for readonly virtiofs support
+            v.major >= 11
+        }
+        None => false,
+    }
+}
+
+/// Execute the libvirt status command
+pub fn run(opts: LibvirtStatusOpts) -> Result<()> {
+    // Get libvirt version
+    let version = parse_libvirt_version()?;
+    let supports_readonly = supports_readonly_virtiofs(&version);
+
+    // Get domain count
+    let lister = DomainLister::new();
+    let all_domains = lister
+        .list_all_domains()
+        .with_context(|| "Failed to list domains")?;
+
+    // Count running domains by checking state
+    let mut running_count = 0;
+    for domain_name in &all_domains {
+        if let Ok(state) = lister.get_domain_state(domain_name) {
+            if state == "running" {
+                running_count += 1;
+            }
+        }
+    }
+
+    let status = LibvirtStatus {
+        version,
+        supports_readonly_virtiofs: supports_readonly,
+        domain_count: all_domains.len(),
+        running_domain_count: running_count,
+    };
+
+    // Output in requested format
+    match opts.format {
+        OutputFormat::Yaml => {
+            println!(
+                "{}",
+                serde_yaml::to_string(&status)
+                    .with_context(|| "Failed to serialize status as YAML")?
+            );
+        }
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&status)
+                    .with_context(|| "Failed to serialize status as JSON")?
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version_string() {
+        // Test full version string
+        let version = parse_version_string("6.2.0").unwrap();
+        assert_eq!(version.major, 6);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.micro, 0);
+        assert_eq!(version.full_version, "6.2.0");
+
+        // Test major.minor only
+        let version = parse_version_string("11.5").unwrap();
+        assert_eq!(version.major, 11);
+        assert_eq!(version.minor, 5);
+        assert_eq!(version.micro, 0);
+        assert_eq!(version.full_version, "11.5");
+
+        // Test major only
+        let version = parse_version_string("12").unwrap();
+        assert_eq!(version.major, 12);
+        assert_eq!(version.minor, 0);
+        assert_eq!(version.micro, 0);
+        assert_eq!(version.full_version, "12");
+
+        // Test invalid version strings
+        assert!(parse_version_string("").is_none());
+        assert!(parse_version_string("not_a_number").is_none());
+
+        // Test version with non-numeric minor version - should work with fallback to 0
+        let version = parse_version_string("6.x.0").unwrap();
+        assert_eq!(version.major, 6);
+        assert_eq!(version.minor, 0); // fallback to 0 for non-numeric
+
+        // Test version with additional parts (should ignore them)
+        let version = parse_version_string("6.2.0.1").unwrap();
+        assert_eq!(version.major, 6);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.micro, 0);
+        assert_eq!(version.full_version, "6.2.0.1");
+    }
+
+    #[test]
+    fn test_parse_libvirt_version_from_output() {
+        // Test typical virsh version output
+        let output = "Compiled against library: libvirt 6.2.0\nUsing library: libvirt 6.2.0\n";
+        let version = parse_libvirt_version_from_output(output).unwrap();
+        assert_eq!(version.major, 6);
+        assert_eq!(version.minor, 2);
+        assert_eq!(version.micro, 0);
+
+        // Test with different format
+        let output = "libvirt 11.0.0\n";
+        let version = parse_libvirt_version_from_output(output).unwrap();
+        assert_eq!(version.major, 11);
+        assert_eq!(version.minor, 0);
+        assert_eq!(version.micro, 0);
+
+        // Test with no libvirt version
+        let output = "Some other output without version\n";
+        assert!(parse_libvirt_version_from_output(output).is_none());
+
+        // Test with libvirt mentioned but no version
+        let output = "libvirt is installed\n";
+        assert!(parse_libvirt_version_from_output(output).is_none());
+    }
+
+    #[test]
+    fn test_supports_readonly_virtiofs() {
+        // Test version that supports readonly virtiofs
+        let version = Some(LibvirtVersion {
+            major: 11,
+            minor: 0,
+            micro: 0,
+            full_version: "11.0.0".to_string(),
+        });
+        assert!(supports_readonly_virtiofs(&version));
+
+        // Test version that doesn't support readonly virtiofs
+        let version = Some(LibvirtVersion {
+            major: 10,
+            minor: 5,
+            micro: 0,
+            full_version: "10.5.0".to_string(),
+        });
+        assert!(!supports_readonly_virtiofs(&version));
+
+        // Test with no version
+        assert!(!supports_readonly_virtiofs(&None));
+
+        // Test edge case - exactly version 11.0.0
+        let version = Some(LibvirtVersion {
+            major: 11,
+            minor: 0,
+            micro: 0,
+            full_version: "11.0.0".to_string(),
+        });
+        assert!(supports_readonly_virtiofs(&version));
+    }
+}

--- a/docs/src/libvirt-run.md
+++ b/docs/src/libvirt-run.md
@@ -131,6 +131,34 @@ bcvk libvirt run \
 - Persistent development state
 - Host integration capabilities
 
+### Container Storage Integration
+
+```bash
+# Create VM with access to host container storage for bootc upgrades
+bcvk libvirt run \
+  --name upgrade-test \
+  --bind-storage-ro \
+  --ssh \
+  quay.io/fedora/fedora-bootc:42
+```
+
+With this, a virtiofs mount named `hoststorage` is provisioned. There isn't
+yet automatic mounting, but you can inject code to do so that performs
+`mkdir -p /run/virtiofs-mnt-hoststorage && mount -t virtiofs hoststorage /run/virtiofs-mnt-hoststorage`.
+
+Then on your host system after you've done a `podman build` that results in a new image `localhost/bootc`,
+in the guest system you can point bootc to use it via e.g.
+```
+env STORAGE_OPTS=additionalimagestore=/run/virtiofs-mnt-hoststorage bootc switch --transport containers-storage localhost/bootc
+```
+
+You currently need to add the `STORAGE_OPTS` each time you invoke `bootc` - but there after e.g.
+```
+env STORAGE_OPTS=additionalimagestore=/run/virtiofs-mnt-hoststorage bootc upgrade
+```
+
+will work.
+
 ## Resource Management Concepts
 
 ### CPU Allocation

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -69,6 +69,10 @@ Run a bootable container as a persistent VM
 
     Automatically SSH into the VM after creation
 
+**--bind-storage-ro**
+
+    Mount host container storage (RO) at /run/virtiofs-mnt-hoststorage
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES
@@ -92,6 +96,10 @@ Create a VM with volume mount:
 Create a VM and automatically SSH into it:
 
     bcvk libvirt run --name testvm --ssh quay.io/fedora/fedora-bootc:42
+
+Create a VM with access to host container storage for bootc upgrade:
+
+    bcvk libvirt run --name upgrade-test --bind-storage-ro quay.io/fedora/fedora-bootc:42
 
 Server management workflow:
 


### PR DESCRIPTION
Implement --bind-storage-ro flag for `bcvk libvirt run` to enable bootc upgrade workflows from persistent VMs by mounting host container storage read-only.

Assisted-by: Claude Code