### PR TITLE
to-disk: Always --skip-fetch-check

### DIFF
--- a/crates/kit/src/to_disk.rs
+++ b/crates/kit/src/to_disk.rs
@@ -175,6 +175,8 @@ impl ToDiskOpts {
             "to-disk",
             // Default to being a generic image here, if someone cares they can override this
             "--generic-image",
+            // The default in newer versions, but support older ones too
+            "--skip-fetch-check",
             "--source-imgref",
         ]
         .into_iter()


### PR DESCRIPTION
So things work with older images too; I wanted to test something in RHEL 9.5 (EOL today) but still useful to cross check.