### PR TITLE
libvirt: Support --connect globally

### DIFF
--- a/crates/kit/src/libvirt/inspect.rs
+++ b/crates/kit/src/libvirt/inspect.rs
@@ -18,16 +18,15 @@ pub struct LibvirtInspectOpts {
 }
 
 /// Execute the libvirt inspect command
-pub fn run(opts: LibvirtInspectOpts) -> Result<()> {
-    inspect_vm_impl(opts)
-}
-
-/// Show detailed information about a VM (implementation)
-pub fn inspect_vm_impl(opts: LibvirtInspectOpts) -> Result<()> {
+pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtInspectOpts) -> Result<()> {
     use crate::domain_list::DomainLister;
     use color_eyre::eyre::Context;
 
-    let lister = DomainLister::new();
+    let connect_uri = global_opts.connect.as_ref();
+    let lister = match connect_uri {
+        Some(uri) => DomainLister::with_connection(uri.clone()),
+        None => DomainLister::new(),
+    };
 
     // Get domain info
     let vm = lister

--- a/crates/kit/src/libvirt/list.rs
+++ b/crates/kit/src/libvirt/list.rs
@@ -19,17 +19,16 @@ pub struct LibvirtListOpts {
 }
 
 /// Execute the libvirt list command
-pub fn run(opts: LibvirtListOpts) -> Result<()> {
-    list_vms_impl(opts)
-}
-
-/// List all VMs (implementation)
-pub fn list_vms_impl(opts: LibvirtListOpts) -> Result<()> {
+pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtListOpts) -> Result<()> {
     use crate::domain_list::DomainLister;
     use color_eyre::eyre::Context;
 
     // Use libvirt as the source of truth for domain listing
-    let lister = DomainLister::new();
+    let connect_uri = global_opts.connect.as_ref();
+    let lister = match connect_uri {
+        Some(uri) => DomainLister::with_connection(uri.clone()),
+        None => DomainLister::new(),
+    };
 
     let domains = if opts.all {
         lister

--- a/crates/kit/src/libvirt/mod.rs
+++ b/crates/kit/src/libvirt/mod.rs
@@ -8,7 +8,6 @@
 //! - `list-volumes`: List available bootc volumes with metadata
 
 use clap::Subcommand;
-use color_eyre::Result;
 
 pub mod create;
 pub mod domain;
@@ -23,9 +22,27 @@ pub mod status;
 pub mod stop;
 pub mod upload;
 
+/// Global options for libvirt operations
+#[derive(Debug, Clone, Default)]
+pub struct LibvirtOptions {
+    /// Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+    pub connect: Option<String>,
+}
+
+impl LibvirtOptions {
+    /// Create a virsh Command with the appropriate connection URI
+    pub fn virsh_command(&self) -> std::process::Command {
+        let mut cmd = std::process::Command::new("virsh");
+        if let Some(ref uri) = self.connect {
+            cmd.arg("-c").arg(uri);
+        }
+        cmd
+    }
+}
+
 /// libvirt subcommands for managing bootc disk images and domains
 #[derive(Debug, Subcommand)]
-pub enum LibvirtCommands {
+pub enum LibvirtSubcommands {
     /// Run a bootable container as a persistent VM
     Run(run::LibvirtRunOpts),
 
@@ -60,22 +77,4 @@ pub enum LibvirtCommands {
 
     /// Create and start domains from uploaded bootc volumes
     Create(create::LibvirtCreateOpts),
-}
-
-impl LibvirtCommands {
-    pub fn run(self) -> Result<()> {
-        match self {
-            LibvirtCommands::Run(opts) => run::run(opts),
-            LibvirtCommands::Ssh(opts) => ssh::run(opts),
-            LibvirtCommands::List(opts) => list::run(opts),
-            LibvirtCommands::ListVolumes(opts) => list_volumes::run(opts),
-            LibvirtCommands::Stop(opts) => stop::run(opts),
-            LibvirtCommands::Start(opts) => start::run(opts),
-            LibvirtCommands::Remove(opts) => rm::run(opts),
-            LibvirtCommands::Inspect(opts) => inspect::run(opts),
-            LibvirtCommands::Status(opts) => status::run(opts),
-            LibvirtCommands::Upload(opts) => upload::run(opts),
-            LibvirtCommands::Create(opts) => create::run(opts),
-        }
-    }
 }

--- a/docs/src/man/bcvk-libvirt-inspect.md
+++ b/docs/src/man/bcvk-libvirt-inspect.md
@@ -25,6 +25,10 @@ Show detailed information about a libvirt domain
 
     Default: yaml
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-list.md
+++ b/docs/src/man/bcvk-libvirt-list.md
@@ -23,6 +23,10 @@ List available bootc volumes with metadata
 
     Show all domains including stopped ones
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-rm.md
+++ b/docs/src/man/bcvk-libvirt-rm.md
@@ -23,6 +23,10 @@ Remove a libvirt domain and its resources
 
     Force removal without confirmation
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 **--stop**
 
     Remove domain even if it's running

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -23,6 +23,10 @@ Run a bootable container as a persistent VM
 
     Name for the VM (auto-generated if not specified)
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)

--- a/docs/src/man/bcvk-libvirt-start.md
+++ b/docs/src/man/bcvk-libvirt-start.md
@@ -23,6 +23,10 @@ Start a stopped libvirt domain
 
     Automatically SSH into the domain after starting
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-stop.md
+++ b/docs/src/man/bcvk-libvirt-stop.md
@@ -23,6 +23,10 @@ Stop a running libvirt domain
 
     Force stop the domain
 
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 **--timeout**=*TIMEOUT*
 
     Timeout in seconds for graceful shutdown

--- a/docs/src/man/bcvk-libvirt.md
+++ b/docs/src/man/bcvk-libvirt.md
@@ -19,7 +19,13 @@ libvirt virtualization infrastructure, enabling:
 - Management of VM lifecycle through libvirt
 - Integration with existing libvirt-based infrastructure
 
+# OPTIONS
+
 <!-- BEGIN GENERATED OPTIONS -->
+**-c**, **--connect**=*CONNECT*
+
+    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
+
 <!-- END GENERATED OPTIONS -->
 
 # SUBCOMMANDS


### PR DESCRIPTION
We really want this for all options consistently, so move it to be part of the libvirt verb and passed down to each sub-option.