### PR TITLE
Fix ssh option processing, change to-disk to use ssh

### DIFF
--- a/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
+++ b/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
@@ -126,7 +126,7 @@ pub fn test_run_ephemeral_ssh_system_command() {
 
     eprintln!("Testing ephemeral run-ssh with system command...");
 
-    // Run ephemeral SSH with systemctl command
+    // Run ephemeral SSH with systemctl command - using /bin/sh -c for shell operators
     let output = Command::new("timeout")
         .args([
             "60s",
@@ -137,10 +137,9 @@ pub fn test_run_ephemeral_ssh_system_command() {
             INTEGRATION_TEST_LABEL,
             &get_test_image(),
             "--",
-            "systemctl",
-            "is-system-running",
-            "||",
-            "true", // Allow non-zero exit for degraded state
+            "/bin/sh",
+            "-c",
+            "systemctl is-system-running || true", // Shell command with operator
         ])
         .output()
         .expect("Failed to run bcvk ephemeral run-ssh");

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -156,6 +156,8 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtRunOpts) -
             command: vec![],
             strict_host_keys: false,
             timeout: 30,
+            log_level: "ERROR".to_string(),
+            extra_options: vec![],
         };
         crate::libvirt::ssh::run(global_opts, ssh_opts)
     } else {

--- a/crates/kit/src/libvirt/start.rs
+++ b/crates/kit/src/libvirt/start.rs
@@ -43,6 +43,8 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtStartOpts)
                 command: vec![],
                 strict_host_keys: false,
                 timeout: 30,
+                log_level: "ERROR".to_string(),
+                extra_options: vec![],
             };
             return crate::libvirt::ssh::run(global_opts, ssh_opts);
         }
@@ -77,6 +79,8 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtStartOpts)
             command: vec![],
             strict_host_keys: false,
             timeout: 30,
+            log_level: "ERROR".to_string(),
+            extra_options: vec![],
         };
         crate::libvirt::ssh::run(global_opts, ssh_opts)
     } else {

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -301,23 +301,6 @@ pub fn run(opts: RunEphemeralOpts) -> Result<()> {
     return Err(cmd.exec()).context("execve");
 }
 
-/// Launch privileged container with QEMU+KVM for ephemeral VM and wait for completion.
-/// Unlike `run()`, this function waits for completion instead of using exec(), making it suitable
-/// for programmatic use where the caller needs to capture output and exit codes.
-pub fn run_synchronous(opts: RunEphemeralOpts) -> Result<()> {
-    let (mut cmd, temp_dir) = prepare_run_command_with_temp(opts)?;
-    // Keep temp_dir alive until command completes
-
-    // Use the same approach as run_detached but wait for completion instead of detaching
-    let status = cmd.status().context("Failed to execute podman command")?;
-    if !status.success() {
-        return Err(color_eyre::eyre::eyre!("ephemeral run failed {status:?}",));
-    }
-    // Explicitly drop temp_dir after successful completion
-    drop(temp_dir);
-    Ok(())
-}
-
 fn prepare_run_command_with_temp(
     opts: RunEphemeralOpts,
 ) -> Result<(std::process::Command, tempfile::TempDir)> {

--- a/crates/kit/src/run_ephemeral_ssh.rs
+++ b/crates/kit/src/run_ephemeral_ssh.rs
@@ -166,7 +166,7 @@ pub fn run_ephemeral_ssh(opts: RunEphemeralSshOpts) -> Result<()> {
 
     // Execute SSH connection directly (no thread needed for this)
     // This allows SSH output to be properly forwarded to stdout/stderr
-    debug!("Connecting to SSH...");
+    debug!("Connecting to SSH with args: {:?}", opts.ssh_args);
     let status = ssh::connect_via_container_with_status(&container_name, opts.ssh_args)?;
     debug!("SSH connection completed");
 

--- a/docs/src/man/bcvk-libvirt-create.md
+++ b/docs/src/man/bcvk-libvirt-create.md
@@ -53,10 +53,6 @@ Create and start domains from uploaded bootc volumes
 
     Enable VNC console access
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 **--vnc-port**=*VNC_PORT*
 
     VNC port (default: auto-assign)

--- a/docs/src/man/bcvk-libvirt-inspect.md
+++ b/docs/src/man/bcvk-libvirt-inspect.md
@@ -25,10 +25,6 @@ Show detailed information about a libvirt domain
 
     Default: yaml
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-list.md
+++ b/docs/src/man/bcvk-libvirt-list.md
@@ -23,10 +23,6 @@ List available bootc volumes with metadata
 
     Show all domains including stopped ones
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-rm.md
+++ b/docs/src/man/bcvk-libvirt-rm.md
@@ -23,10 +23,6 @@ Remove a libvirt domain and its resources
 
     Force removal without confirmation
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 **--stop**
 
     Remove domain even if it's running

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -23,10 +23,6 @@ Run a bootable container as a persistent VM
 
     Name for the VM (auto-generated if not specified)
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)

--- a/docs/src/man/bcvk-libvirt-ssh.md
+++ b/docs/src/man/bcvk-libvirt-ssh.md
@@ -23,10 +23,6 @@ SSH to libvirt domain with embedded SSH key
 
     Command to execute on remote host
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 **--user**=*USER*
 
     SSH username to use for connection (defaults to 'root')

--- a/docs/src/man/bcvk-libvirt-ssh.md
+++ b/docs/src/man/bcvk-libvirt-ssh.md
@@ -39,6 +39,16 @@ SSH to libvirt domain with embedded SSH key
 
     Default: 30
 
+**--log-level**=*LOG_LEVEL*
+
+    SSH log level
+
+    Default: ERROR
+
+**--extra-options**=*EXTRA_OPTIONS*
+
+    Extra SSH options in key=value format
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-start.md
+++ b/docs/src/man/bcvk-libvirt-start.md
@@ -23,10 +23,6 @@ Start a stopped libvirt domain
 
     Automatically SSH into the domain after starting
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES

--- a/docs/src/man/bcvk-libvirt-stop.md
+++ b/docs/src/man/bcvk-libvirt-stop.md
@@ -23,10 +23,6 @@ Stop a running libvirt domain
 
     Force stop the domain
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 **--timeout**=*TIMEOUT*
 
     Timeout in seconds for graceful shutdown

--- a/docs/src/man/bcvk-libvirt-upload.md
+++ b/docs/src/man/bcvk-libvirt-upload.md
@@ -59,10 +59,6 @@ Upload bootc disk images to libvirt with metadata annotations
 
     Additional kernel arguments for installation
 
-**-c**, **--connect**=*CONNECT*
-
-    Hypervisor connection URI (e.g., qemu:///system, qemu+ssh://host/system)
-
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES


### PR DESCRIPTION

I got bit badly by the problem that `ssh` always runs
a remote shell and basically just does the completely
wrong thing if you pass it multiple things
in argv.

While we're here fix things so libvirt and ephemeral
share more code.

Signed-off-by: Colin Walters <walters@verbum.org>