### PR TITLE
ci: Fix release workflow authentication for tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# Keep this in sync with the code in bootc-dev/bootc
 name: Release
 
 on:
@@ -27,7 +28,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
 
       - name: Extract version
         id: extract_version
@@ -68,9 +68,10 @@ jobs:
 
           git tag -s -m "Release $VERSION" "$TAG_NAME"
           git push origin "$TAG_NAME"
-          git checkout "$TAG_NAME"
 
           echo "Successfully created and pushed tag $TAG_NAME"
+
+          git checkout "$TAG_NAME"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,3 +1,5 @@
+# Keep this in sync with the code in bootc-dev/bootc
+
 name: Create Release PR
 
 on:


### PR DESCRIPTION
## Summary

Fixes #40 - the automated release workflow failure due to git push authentication error.

## Changes

- Remove `persist-credentials: false` from the checkout step in the release workflow
- Add sync comments to align with bootc workflow structure

## Root Cause

The workflow had `persist-credentials: false` which removed Git credentials after checkout. When the workflow later tried to `git push origin "$TAG_NAME"`, it failed with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Solution

By removing `persist-credentials: false` (using the default `true` behavior), the `actions/checkout@v4` action now configures git with the GitHub App token via `http.extraheader`, allowing the subsequent `git push` to authenticate successfully.

This aligns with how the bootc release workflow handles authentication.

## Testing

This change should allow the next release PR to successfully:
1. Create a signed tag
2. Push the tag to the remote repository
3. Continue with the build and release process

🤖 Generated with [Claude Code](https://claude.com/claude-code)