### PR TITLE
libvirt: Use all vcpus for install

### DIFF
--- a/crates/kit/src/libvirt/base_disks.rs
+++ b/crates/kit/src/libvirt/base_disks.rs
@@ -120,8 +120,6 @@ fn create_base_disk(
                 memory: crate::common_opts::MemoryOpts {
                     memory: super::LIBVIRT_DEFAULT_MEMORY.to_string(),
                 },
-                vcpus: Some(super::LIBVIRT_DEFAULT_VCPUS),
-                ssh_keygen: false, // Base disks don't need SSH keys
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
Right now composefs based installs are slow...while we do need to give libvirt a limit for the resulting system, use all CPUs by default for install time.