### PR TITLE
ephemeral: Default to bridged networking

### DIFF
--- a/crates/kit/src/libvirt/upload.rs
+++ b/crates/kit/src/libvirt/upload.rs
@@ -220,7 +220,6 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtUploadOpts
                 memory: opts.memory.clone(),
                 vcpus: opts.vcpus,
                 kernel_args: opts.karg.clone(),
-                net: Some("none".to_string()),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kit/src/libvirt_upload_disk.rs
+++ b/crates/kit/src/libvirt_upload_disk.rs
@@ -291,7 +291,6 @@ pub fn run(opts: LibvirtUploadDiskOpts) -> Result<()> {
                 memory: opts.memory.clone(),
                 vcpus: opts.vcpus,
                 kernel_args: opts.karg.clone(),
-                net: Some("none".to_string()),
                 ..Default::default()
             },
             ..Default::default()

--- a/docs/src/man/bcvk-ephemeral-run-ssh.md
+++ b/docs/src/man/bcvk-ephemeral-run-ssh.md
@@ -37,10 +37,6 @@ Run ephemeral VM and SSH into it
 
     Additional kernel command line arguments
 
-**--net**=*NET*
-
-    Network configuration (none, user, bridge=name) [default: none]
-
 **--console**
 
     Enable console output to terminal for debugging
@@ -80,6 +76,10 @@ Run ephemeral VM and SSH into it
 **--name**=*NAME*
 
     Assign a name to the container
+
+**--network**=*NETWORK*
+
+    Configure the network for the container
 
 **--label**=*LABEL*
 

--- a/docs/src/man/bcvk-ephemeral-run.md
+++ b/docs/src/man/bcvk-ephemeral-run.md
@@ -63,10 +63,6 @@ This design allows bcvk to provide VM-like isolation and boot behavior while lev
 
     Additional kernel command line arguments
 
-**--net**=*NET*
-
-    Network configuration (none, user, bridge=name) [default: none]
-
 **--console**
 
     Enable console output to terminal for debugging
@@ -106,6 +102,10 @@ This design allows bcvk to provide VM-like isolation and boot behavior while lev
 **--name**=*NAME*
 
     Assign a name to the container
+
+**--network**=*NETWORK*
+
+    Configure the network for the container
 
 **--label**=*LABEL*
 

--- a/docs/src/man/bcvk-to-disk.md
+++ b/docs/src/man/bcvk-to-disk.md
@@ -79,10 +79,6 @@ The installation process:
 
     Additional kernel command line arguments
 
-**--net**=*NET*
-
-    Network configuration (none, user, bridge=name) [default: none]
-
 **--console**
 
     Enable console output to terminal for debugging


### PR DESCRIPTION
There's no reason to default to `none` - let's make it match the podman default. In my testing this works except for DNS in the guest - haven't debugged why yet.