### PR TITLE
virtiofs: Fix writable virtiofs mounts

### DIFF
--- a/crates/kit/src/qemu.rs
+++ b/crates/kit/src/qemu.rs
@@ -898,6 +898,8 @@ pub struct VirtiofsConfig {
     /// Host directory to share
     pub shared_dir: Utf8PathBuf,
     pub debug: bool,
+    /// Mount as read-only
+    pub readonly: bool,
 }
 
 impl Default for VirtiofsConfig {
@@ -906,6 +908,8 @@ impl Default for VirtiofsConfig {
             socket_path: "/run/inner-shared/virtiofs.sock".into(),
             shared_dir: "/run/source-image".into(),
             debug: false,
+            // We don't need to write to this, there's a transient overlay
+            readonly: true,
         }
     }
 }
@@ -977,8 +981,8 @@ pub async fn spawn_virtiofsd_async(config: &VirtiofsConfig) -> Result<tokio::pro
         "--sandbox=none",
     ]);
 
-    // Only add --readonly if supported
-    if supports_readonly {
+    // Only add --readonly if requested and supported
+    if config.readonly && supports_readonly {
         cmd.arg("--readonly");
     }
 

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -824,6 +824,7 @@ pub(crate) async fn run_impl(opts: RunEphemeralOpts) -> Result<()> {
                 socket_path: socket_path.clone().into(),
                 shared_dir: source_path,
                 debug: false,
+                readonly: is_readonly,
             };
             additional_mounts.push((virtiofsd_config, tag.clone()));
 


### PR DESCRIPTION
Regression from previous commit; we unconditionally added `--readonly` if virtiofsd supported it (which it doesn't yet in the Ubuntu 24.04 but does in Fedora 42+).

We want to support writable mounts.

It turns out the integration tests didn't catch this because they only looked at the permission bits.