### PR TITLE
libvirt: Support extracting SSH connection data

### DIFF
--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -251,6 +251,10 @@ fn main() {
             tests::libvirt_verb::test_libvirt_list_json_output();
             Ok(())
         }),
+        Trial::test("libvirt_list_json_ssh_metadata", || {
+            tests::libvirt_verb::test_libvirt_list_json_ssh_metadata();
+            Ok(())
+        }),
         Trial::test("libvirt_run_resource_options", || {
             tests::libvirt_verb::test_libvirt_run_resource_options();
             Ok(())

--- a/docs/src/man/bcvk-libvirt-list.md
+++ b/docs/src/man/bcvk-libvirt-list.md
@@ -4,15 +4,27 @@ bcvk-libvirt-list - List available bootc volumes with metadata
 
 # SYNOPSIS
 
-**bcvk libvirt list** [*OPTIONS*]
+**bcvk libvirt list** [*DOMAIN_NAME*] [*OPTIONS*]
 
 # DESCRIPTION
 
-List available bootc volumes with metadata
+List available bootc domains with metadata. When a domain name is provided, returns information about that specific domain only.
+
+When using `--format=json` with a specific domain name, the output is a single JSON object (not an array), making it easy to extract SSH credentials and connection information using tools like `jq`.
+
+# OPTIONS
+
+**DOMAIN_NAME**
+
+    Optional domain name to query. When specified, returns information about only this domain.
 
 # OPTIONS
 
 <!-- BEGIN GENERATED OPTIONS -->
+**DOMAIN_NAME**
+
+    Domain name to query (returns only this domain)
+
 **--format**=*FORMAT*
 
     Output format
@@ -48,9 +60,38 @@ Show VM status in your workflow:
 
     # Check what VMs are running
     bcvk libvirt list
-    
+
     # Start a specific VM if needed
     bcvk libvirt start my-server
+
+Query a specific domain:
+
+    bcvk libvirt list my-domain
+
+## Working with SSH credentials via JSON output
+
+Connect via SSH using extracted credentials:
+
+    # Query once, save to file, then extract credentials
+    DOMAIN_NAME="mydomain"
+
+    # Query domain info once and save to file
+    bcvk libvirt list $DOMAIN_NAME --format=json > /tmp/domain-info.json
+
+    # Extract SSH private key
+    jq -r '.ssh_private_key' /tmp/domain-info.json > /tmp/key.pem
+    chmod 600 /tmp/key.pem
+
+    # Extract SSH port
+    SSH_PORT=$(jq -r '.ssh_port' /tmp/domain-info.json)
+
+    # Connect via SSH
+    ssh -o IdentitiesOnly=yes -i /tmp/key.pem -p $SSH_PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1
+
+    # Cleanup
+    rm /tmp/domain-info.json /tmp/key.pem
+
+This is useful for automation scripts or when you need direct SSH access without using `bcvk libvirt ssh`.
 
 # SEE ALSO
 


### PR DESCRIPTION
I'm looking at using bcvk to create libvirt VMs
that are targets for tmt, like
https://github.com/bootc-dev/bootc/commit/54f8562dadcd64f80469145afed0bc997bb1f245#diff-dad7b84674fccc140b0fb2f17af742872a2f5cda5ddd36af501f39b404baf0cbR70 was doing.