### PR TITLE
libvirt: Add support for --transient

### DIFF
--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -283,6 +283,10 @@ fn main() {
             tests::libvirt_verb::test_libvirt_bind_storage_ro();
             Ok(())
         }),
+        Trial::test("libvirt_transient_vm", || {
+            tests::libvirt_verb::test_libvirt_transient_vm();
+            Ok(())
+        }),
         Trial::test("libvirt_base_disk_creation_and_reuse", || {
             tests::libvirt_base_disks::test_base_disk_creation_and_reuse();
             Ok(())

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -106,6 +106,10 @@ Run a bootable container as a persistent VM
 
     User-defined labels for organizing VMs (comma not allowed in labels)
 
+**--transient**
+
+    Create a transient VM that disappears on shutdown/reboot
+
 <!-- END GENERATED OPTIONS -->
 
 # EXAMPLES


### PR DESCRIPTION
The use case here is ephemeral VMs for CI tests; we don't want to leak them across host updates and it's more efficient to not create persistent disks for them.