### PR TITLE
Always allocate an emulated and a virtio console

### DIFF
--- a/crates/kit/src/libvirt/domain.rs
+++ b/crates/kit/src/libvirt/domain.rs
@@ -340,13 +340,14 @@ impl DomainBuilder {
             }
         }
 
-        // Serial console
-        writer.start_element("serial", &[("type", "pty")])?;
-        writer.write_empty_element("target", &[("port", "0")])?;
-        writer.end_element("serial")?;
-
+        // Serial console, see https://libvirt.org/formatdomain.html#relationship-between-serial-ports-and-consoles
+        // We allocate a platform-specific default for early console stuff like bootloaders,
+        // and a platform-independent `hvc0` that can be referenced independently.
         writer.start_element("console", &[("type", "pty")])?;
-        writer.write_empty_element("target", &[("type", "serial"), ("port", "0")])?;
+        writer.write_empty_element("target", &[("type", "serial")])?;
+        writer.end_element("console")?;
+        writer.start_element("console", &[("type", "pty")])?;
+        writer.write_empty_element("target", &[("type", "virtio")])?;
         writer.end_element("console")?;
 
         // VNC graphics if enabled

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -972,7 +972,7 @@ StandardOutput=file:/dev/virtio-ports/executestatus
     ];
 
     if opts.common.console {
-        kernel_cmdline.push("console=ttyS0".to_string());
+        kernel_cmdline.push("console=hvc0".to_string());
     }
     if cloudinit {
         // We don't provide any cloud-init datasource right now,


### PR DESCRIPTION
I want to build on this in higher level things because we can rely on `hvc0` always being used.