### PR TITLE
libvirt: Fix memory display unit conversion

### DIFF
--- a/crates/kit/src/domain_list.rs
+++ b/crates/kit/src/domain_list.rs
@@ -192,10 +192,7 @@ impl DomainLister {
             .unwrap_or_default();
 
         // Extract memory and vcpu from domain XML
-        let memory_mb = dom.find("memory").and_then(|node| {
-            // Memory might have unit attribute, but we'll try to parse the value
-            node.text_content().parse::<u32>().ok()
-        });
+        let memory_mb = dom.find("memory").and_then(|node| node.parse_memory_mb());
 
         let vcpus = dom
             .find("vcpu")

--- a/crates/kit/src/lib.rs
+++ b/crates/kit/src/lib.rs
@@ -1,4 +1,5 @@
 //! bcvk library - exposes internal modules for testing
 
 pub mod qemu_img;
+pub mod utils;
 pub mod xml_utils;


### PR DESCRIPTION
Fix incorrect memory display in `bcvk libvirt list --all`

Assisted-by: Claude Code