### PR TITLE
libvirt: Add creation timestamp to base disks output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "color-eyre",
  "dirs",
  "libtest-mimic",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -31,3 +31,4 @@ libtest-mimic = "0.7.3"
 tempfile = "3"
 uuid = { version = "1.18.1", features = ["v4"] }
 camino = "1.1.12"
+regex = "1"

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -299,6 +299,10 @@ fn main() {
             tests::libvirt_base_disks::test_base_disks_list_command();
             Ok(())
         }),
+        Trial::test("libvirt_base_disks_list_shows_timestamp", || {
+            tests::libvirt_base_disks::test_base_disks_list_shows_timestamp();
+            Ok(())
+        }),
         Trial::test("libvirt_base_disks_prune_dry_run", || {
             tests::libvirt_base_disks::test_base_disks_prune_dry_run();
             Ok(())

--- a/crates/kit/src/libvirt/base_disks.rs
+++ b/crates/kit/src/libvirt/base_disks.rs
@@ -320,8 +320,10 @@ pub fn list_base_disks(connect_uri: Option<&str>) -> Result<Vec<BaseDiskInfo>> {
                         )
                         .unwrap_or(None);
 
-                    // Get file size
-                    let size = entry.metadata().ok().map(|m| m.len());
+                    // Get file size and creation time
+                    let metadata = entry.metadata().ok();
+                    let size = metadata.as_ref().map(|m| m.len());
+                    let created = metadata.and_then(|m| m.created().ok());
 
                     // Count references
                     let ref_count = count_base_disk_references(&path, &vm_disks)?;
@@ -331,6 +333,7 @@ pub fn list_base_disks(connect_uri: Option<&str>) -> Result<Vec<BaseDiskInfo>> {
                         image_digest,
                         size,
                         ref_count,
+                        created,
                     });
                 }
             }
@@ -347,6 +350,7 @@ pub struct BaseDiskInfo {
     pub image_digest: Option<String>,
     pub size: Option<u64>,
     pub ref_count: usize,
+    pub created: Option<std::time::SystemTime>,
 }
 
 /// Prune unreferenced base disks


### PR DESCRIPTION
Because it's useful to know.