### PR TITLE
tests/integration: Use linkme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "color-eyre",
  "dirs",
  "libtest-mimic",
+ "linkme",
  "regex",
  "serde",
  "serde_json",
@@ -1449,6 +1450,26 @@ dependencies = [
  "escape8259",
  "termcolor",
  "threadpool",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -32,3 +32,4 @@ tempfile = "3"
 uuid = { version = "1.18.1", features = ["v4"] }
 camino = "1.1.12"
 regex = "1"
+linkme = "0.3.30"

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -3,8 +3,33 @@
 //! This module contains constants and utilities that are shared between
 //! the main test binary and helper binaries like cleanup.
 
+// Unfortunately needed here to work with linkme
+#![allow(unsafe_code)]
+
+use linkme::distributed_slice;
+
 /// Label used to identify containers created by integration tests
 pub const INTEGRATION_TEST_LABEL: &str = "bcvk.integration-test=1";
 
 /// Label used to identify libvirt VMs created by integration tests
 pub const LIBVIRT_INTEGRATION_TEST_LABEL: &str = "bcvk-integration";
+
+/// A test function that returns a Result
+pub type TestFn = fn() -> color_eyre::Result<()>;
+
+/// Metadata for a registered integration test
+#[derive(Debug)]
+pub struct IntegrationTest {
+    pub name: &'static str,
+    pub f: TestFn,
+}
+
+impl IntegrationTest {
+    pub const fn new(name: &'static str, f: TestFn) -> Self {
+        Self { name, f }
+    }
+}
+
+/// Distributed slice holding all registered integration tests
+#[distributed_slice]
+pub static INTEGRATION_TESTS: [IntegrationTest];

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -8,7 +8,10 @@ use serde_json::Value;
 use xshell::{cmd, Shell};
 
 // Re-export constants from lib for internal use
-pub(crate) use integration_tests::{INTEGRATION_TEST_LABEL, LIBVIRT_INTEGRATION_TEST_LABEL};
+pub(crate) use integration_tests::{
+    IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL, LIBVIRT_INTEGRATION_TEST_LABEL,
+};
+use linkme::distributed_slice;
 
 mod tests {
     pub mod libvirt_base_disks;
@@ -129,6 +132,9 @@ pub(crate) fn run_bcvk_nocapture(args: &[&str]) -> std::io::Result<()> {
     Ok(())
 }
 
+#[distributed_slice(INTEGRATION_TESTS)]
+static TEST_IMAGES_LIST: IntegrationTest = IntegrationTest::new("images_list", test_images_list);
+
 fn test_images_list() -> Result<()> {
     println!("Running test: bcvk images list --json");
 
@@ -174,144 +180,15 @@ fn test_images_list() -> Result<()> {
 fn main() {
     let args = Arguments::from_args();
 
-    let tests = vec![
-        Trial::test("images_list", || {
-            test_images_list()?;
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_correct_kernel", || {
-            tests::run_ephemeral::test_run_ephemeral_correct_kernel();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_poweroff", || {
-            tests::run_ephemeral::test_run_ephemeral_poweroff();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_with_memory_limit", || {
-            tests::run_ephemeral::test_run_ephemeral_with_memory_limit();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_with_vcpus", || {
-            tests::run_ephemeral::test_run_ephemeral_with_vcpus();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_execute", || {
-            tests::run_ephemeral::test_run_ephemeral_execute();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_container_ssh_access", || {
-            tests::run_ephemeral::test_run_ephemeral_container_ssh_access();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_ssh_command", || {
-            tests::run_ephemeral_ssh::test_run_ephemeral_ssh_command();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_ssh_cleanup", || {
-            tests::run_ephemeral_ssh::test_run_ephemeral_ssh_cleanup();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_ssh_system_command", || {
-            tests::run_ephemeral_ssh::test_run_ephemeral_ssh_system_command();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_ssh_exit_code", || {
-            tests::run_ephemeral_ssh::test_run_ephemeral_ssh_exit_code();
-            Ok(())
-        }),
-        Trial::test("run_ephemeral_ssh_cross_distro_compatibility", || {
-            tests::run_ephemeral_ssh::test_run_ephemeral_ssh_cross_distro_compatibility();
-            Ok(())
-        }),
-        Trial::test("mount_feature_bind", || {
-            tests::mount_feature::test_mount_feature_bind();
-            Ok(())
-        }),
-        Trial::test("mount_feature_ro_bind", || {
-            tests::mount_feature::test_mount_feature_ro_bind();
-            Ok(())
-        }),
-        Trial::test("to_disk", || {
-            tests::to_disk::test_to_disk();
-            Ok(())
-        }),
-        Trial::test("to_disk_qcow2", || {
-            tests::to_disk::test_to_disk_qcow2();
-            Ok(())
-        }),
-        Trial::test("to_disk_caching", || {
-            tests::to_disk::test_to_disk_caching();
-            Ok(())
-        }),
-        Trial::test("libvirt_list_functionality", || {
-            tests::libvirt_verb::test_libvirt_list_functionality();
-            Ok(())
-        }),
-        Trial::test("libvirt_list_json_output", || {
-            tests::libvirt_verb::test_libvirt_list_json_output();
-            Ok(())
-        }),
-        Trial::test("libvirt_list_json_ssh_metadata", || {
-            tests::libvirt_verb::test_libvirt_list_json_ssh_metadata();
-            Ok(())
-        }),
-        Trial::test("libvirt_run_resource_options", || {
-            tests::libvirt_verb::test_libvirt_run_resource_options();
-            Ok(())
-        }),
-        Trial::test("libvirt_run_networking", || {
-            tests::libvirt_verb::test_libvirt_run_networking();
-            Ok(())
-        }),
-        Trial::test("libvirt_ssh_integration", || {
-            tests::libvirt_verb::test_libvirt_ssh_integration();
-            Ok(())
-        }),
-        Trial::test("libvirt_run_ssh_full_workflow", || {
-            tests::libvirt_verb::test_libvirt_run_ssh_full_workflow();
-            Ok(())
-        }),
-        Trial::test("libvirt_vm_lifecycle", || {
-            tests::libvirt_verb::test_libvirt_vm_lifecycle();
-            Ok(())
-        }),
-        Trial::test("libvirt_label_functionality", || {
-            tests::libvirt_verb::test_libvirt_label_functionality();
-            Ok(())
-        }),
-        Trial::test("libvirt_error_handling", || {
-            tests::libvirt_verb::test_libvirt_error_handling();
-            Ok(())
-        }),
-        Trial::test("libvirt_bind_storage_ro", || {
-            tests::libvirt_verb::test_libvirt_bind_storage_ro();
-            Ok(())
-        }),
-        Trial::test("libvirt_transient_vm", || {
-            tests::libvirt_verb::test_libvirt_transient_vm();
-            Ok(())
-        }),
-        Trial::test("libvirt_base_disk_creation_and_reuse", || {
-            tests::libvirt_base_disks::test_base_disk_creation_and_reuse();
-            Ok(())
-        }),
-        Trial::test("libvirt_base_disks_list_command", || {
-            tests::libvirt_base_disks::test_base_disks_list_command();
-            Ok(())
-        }),
-        Trial::test("libvirt_base_disks_list_shows_timestamp", || {
-            tests::libvirt_base_disks::test_base_disks_list_shows_timestamp();
-            Ok(())
-        }),
-        Trial::test("libvirt_base_disks_prune_dry_run", || {
-            tests::libvirt_base_disks::test_base_disks_prune_dry_run();
-            Ok(())
-        }),
-        Trial::test("libvirt_vm_disk_references_base", || {
-            tests::libvirt_base_disks::test_vm_disk_references_base();
-            Ok(())
-        }),
-    ];
+    // Collect tests from the distributed slice
+    let tests: Vec<Trial> = INTEGRATION_TESTS
+        .iter()
+        .map(|test| {
+            let name = test.name;
+            let f = test.f;
+            Trial::test(name, move || f().map_err(|e| format!("{:?}", e).into()))
+        })
+        .collect();
 
     // Run the tests and exit with the result
     libtest_mimic::run(&args, tests).exit();

--- a/crates/integration-tests/src/tests/mount_feature.rs
+++ b/crates/integration-tests/src/tests/mount_feature.rs
@@ -15,10 +15,12 @@
 //! - Warning and continuing on failures
 
 use camino::Utf8Path;
+use color_eyre::Result;
+use linkme::distributed_slice;
 use std::fs;
 use tempfile::TempDir;
 
-use crate::{get_test_image, run_bcvk, INTEGRATION_TEST_LABEL};
+use crate::{get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
 
 /// Create a systemd unit that verifies a mount exists and tests writability
 fn create_mount_verify_unit(
@@ -66,7 +68,11 @@ StandardError=journal+console
     Ok(())
 }
 
-pub fn test_mount_feature_bind() {
+#[distributed_slice(INTEGRATION_TESTS)]
+static TEST_MOUNT_FEATURE_BIND: IntegrationTest =
+    IntegrationTest::new("mount_feature_bind", test_mount_feature_bind);
+
+fn test_mount_feature_bind() -> Result<()> {
     // Create a temporary directory to test bind mounting
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let temp_dir_path = Utf8Path::from_path(temp_dir.path()).expect("temp dir path is not utf8");
@@ -110,15 +116,19 @@ pub fn test_mount_feature_bind() {
         "--karg",
         "systemd.journald.forward_to_console=1",
         &get_test_image(),
-    ])
-    .expect("Failed to run bcvk with bind mount");
+    ])?;
 
     assert!(output.stdout.contains("ok mount verify"));
 
     println!("Successfully tested and verified bind mount feature");
+    Ok(())
 }
 
-pub fn test_mount_feature_ro_bind() {
+#[distributed_slice(INTEGRATION_TESTS)]
+static TEST_MOUNT_FEATURE_RO_BIND: IntegrationTest =
+    IntegrationTest::new("mount_feature_ro_bind", test_mount_feature_ro_bind);
+
+fn test_mount_feature_ro_bind() -> Result<()> {
     // Create a temporary directory to test read-only bind mounting
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let temp_dir_path = Utf8Path::from_path(temp_dir.path()).expect("temp dir path is not utf8");
@@ -158,8 +168,8 @@ pub fn test_mount_feature_ro_bind() {
         "--karg",
         "systemd.journald.forward_to_console=1",
         &get_test_image(),
-    ])
-    .expect("Failed to run bcvk with ro-bind mount");
+    ])?;
 
     assert!(output.stdout.contains("ok mount verify"));
+    Ok(())
 }


### PR DESCRIPTION
This keeps tests defined in one place, same as main Rust `#[test]`, reducing conflicts and context switching.