### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ disk images that can be imported into other virtualization frameworks.
 
 ## Installation
 
-For now `git clone && cargo build --release`.
+See [docs/src/installation.md](./docs/src/installation.md).
 
 ## Quick Start
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -18,17 +18,16 @@ Optional:
 
 ## Building from Source
 
+Without cloning the repo:
+
 ```bash
-git clone https://github.com/cgwalters/bcvk.git
-cd bcvk
-cargo build --release
+cargo install --locked --git https://github.com/bootc-dev/bcvk bcvk
 ```
 
-Binary location: `target/release/bcvk`
+Inside a clone of the repo:
 
-Install to PATH:
 ```bash
-sudo cp target/release/bcvk /usr/local/bin/
+cargo install --locked --path crates/kit
 ```
 
 ## Platform Support


### PR DESCRIPTION
Since cargo can install from git repository URLs directly, a separate `git clone` step is unnecessary.

Reference the detailed installation page from the readme to avoid duplication and inconsistencies.
