### PR TITLE
homebrew: Add Homebrew tap support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,3 +76,18 @@ jobs:
             target/bcvk-*.tar.gz
             target/bcvk-*.tar.gz.sha256
           retention-days: 7
+
+  homebrew-formula:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Test formula
+        run: |
+          brew tap bootc-dev/bcvk ${{ github.workspace }}
+          brew install --build-from-source --verbose bootc-dev/bcvk/bcvk
+          bcvk --help

--- a/bcvk.rb
+++ b/bcvk.rb
@@ -1,0 +1,30 @@
+class Bcvk < Formula
+  desc "Bootc virtualization kit - launch ephemeral VMs and create disk images from bootc containers"
+  homepage "https://github.com/bootc-dev/bcvk"
+  url "https://github.com/bootc-dev/bcvk/archive/refs/tags/v0.5.3.tar.gz"
+  sha256 "67c632b26513f77edcf63b3da8b22941a4ef467c984bfce301544533a1f12979"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/bootc-dev/bcvk.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "pkg-config" => :build
+  depends_on "openssl@3"
+
+  def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_NO_VENDOR"] = "1"
+    system "cargo", "install", *std_cargo_args(path: "crates/kit")
+  end
+
+  test do
+    # Test that the binary exists and help works
+    output = shell_output("#{bin}/bcvk --help")
+    assert_match "bootc", output
+    assert_match "Usage: bcvk <COMMAND>", output
+
+    # Test that subcommands are available
+    assert_match "ephemeral", output
+    assert_match "to-disk", output
+    assert_match "libvirt", output
+  end
+end

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 Required:
-- [Rust](https://www.rust-lang.org/)
+- [Rust](https://www.rust-lang.org/) (if building from source)
 - Git
 - QEMU/KVM
 - virtiofsd
@@ -15,6 +15,20 @@ Optional:
   sudo systemctl enable --now libvirtd
   sudo usermod -a -G libvirt $USER
   ```
+
+## Homebrew (Linux)
+
+Install from the bcvk tap:
+
+```bash
+brew install bootc-dev/bcvk/bcvk
+```
+
+Or install the latest development version:
+
+```bash
+brew install --HEAD bootc-dev/bcvk/bcvk
+```
 
 ## Building from Source
 


### PR DESCRIPTION
This adds a Homebrew formula for bcvk, addressing issue #100.

The formula supports both stable releases and HEAD installations. Users can install with:
  brew install bootc-dev/bcvk/bcvk

Closes: https://github.com/bootc-dev/bcvk/issues/100

Assisted-by: Claude Code (Sonnet 4.5)