### PR TITLE
ephemeral: Never pull

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -374,6 +374,9 @@ fn prepare_run_command_with_temp(
     // Run the container with the setup script
     let mut cmd = Command::new("podman");
     cmd.arg("run");
+    // We don't do pulling because then we'd have to propagate all the authfile
+    // and status output for that in the general case.
+    cmd.arg("--pull=never");
     // We always have a label
     cmd.arg("--label=bcvk.ephemeral=1");
     for label in opts.podman.label.iter() {


### PR DESCRIPTION
I think we should only operate on extant container images, we're not the same thing as `podman|docker run` in that sense.