### PR TITLE
feat: Add KubeVirt common-instancetypes support

### DIFF
--- a/crates/kit/src/instancetypes.rs
+++ b/crates/kit/src/instancetypes.rs
@@ -1,0 +1,146 @@
+//! KubeVirt common-instancetypes support
+//!
+//! This module vendors the KubeVirt common-instancetypes definitions,
+//! specifically the U series (Universal/General Purpose) instance types.
+//! These provide standardized VM sizing with predefined vCPU and memory
+//! configurations.
+//!
+//! Instance types follow the format: u1.{size}
+//! Examples: u1.nano, u1.micro, u1.small, u1.medium, u1.large, etc.
+//!
+//! Source: https://github.com/kubevirt/common-instancetypes
+
+/// Instance type variants with associated vCPU and memory specifications
+///
+/// Source: https://github.com/kubevirt/common-instancetypes/blob/main/instancetypes/u/1/sizes.yaml
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::Display,
+    strum::EnumString,
+    strum::EnumIter,
+)]
+#[non_exhaustive]
+pub enum InstanceType {
+    /// u1.nano - 1 vCPU, 512 MiB memory
+    #[strum(serialize = "u1.nano")]
+    U1Nano,
+    /// u1.micro - 1 vCPU, 1 GiB memory
+    #[strum(serialize = "u1.micro")]
+    U1Micro,
+    /// u1.small - 1 vCPU, 2 GiB memory
+    #[strum(serialize = "u1.small")]
+    U1Small,
+    /// u1.medium - 1 vCPU, 4 GiB memory
+    #[strum(serialize = "u1.medium")]
+    U1Medium,
+    /// u1.2xmedium - 2 vCPU, 4 GiB memory
+    #[strum(serialize = "u1.2xmedium")]
+    U1TwoXMedium,
+    /// u1.large - 2 vCPU, 8 GiB memory
+    #[strum(serialize = "u1.large")]
+    U1Large,
+    /// u1.xlarge - 4 vCPU, 16 GiB memory
+    #[strum(serialize = "u1.xlarge")]
+    U1XLarge,
+    /// u1.2xlarge - 8 vCPU, 32 GiB memory
+    #[strum(serialize = "u1.2xlarge")]
+    U1TwoXLarge,
+    /// u1.4xlarge - 16 vCPU, 64 GiB memory
+    #[strum(serialize = "u1.4xlarge")]
+    U1FourXLarge,
+    /// u1.8xlarge - 32 vCPU, 128 GiB memory
+    #[strum(serialize = "u1.8xlarge")]
+    U1EightXLarge,
+}
+
+impl InstanceType {
+    /// Get the number of vCPUs for this instance type
+    pub const fn vcpus(self) -> u32 {
+        match self {
+            Self::U1Nano => 1,
+            Self::U1Micro => 1,
+            Self::U1Small => 1,
+            Self::U1Medium => 1,
+            Self::U1TwoXMedium => 2,
+            Self::U1Large => 2,
+            Self::U1XLarge => 4,
+            Self::U1TwoXLarge => 8,
+            Self::U1FourXLarge => 16,
+            Self::U1EightXLarge => 32,
+        }
+    }
+
+    /// Get the memory in megabytes for this instance type
+    pub const fn memory_mb(self) -> u32 {
+        match self {
+            Self::U1Nano => 512,
+            Self::U1Micro => 1024,
+            Self::U1Small => 2048,
+            Self::U1Medium => 4096,
+            Self::U1TwoXMedium => 4096,
+            Self::U1Large => 8192,
+            Self::U1XLarge => 16384,
+            Self::U1TwoXLarge => 32768,
+            Self::U1FourXLarge => 65536,
+            Self::U1EightXLarge => 131072,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn test_properties() {
+        for variant in InstanceType::iter() {
+            let (expected_vcpus, expected_memory_mb) = match variant {
+                InstanceType::U1Nano => (1, 512),
+                InstanceType::U1Micro => (1, 1024),
+                InstanceType::U1Small => (1, 2048),
+                InstanceType::U1Medium => (1, 4096),
+                InstanceType::U1TwoXMedium => (2, 4096),
+                InstanceType::U1Large => (2, 8192),
+                InstanceType::U1XLarge => (4, 16384),
+                InstanceType::U1TwoXLarge => (8, 32768),
+                InstanceType::U1FourXLarge => (16, 65536),
+                InstanceType::U1EightXLarge => (32, 131072),
+            };
+            assert_eq!(
+                variant.vcpus(),
+                expected_vcpus,
+                "Mismatch in vcpus for {:?}",
+                variant
+            );
+            assert_eq!(
+                variant.memory_mb(),
+                expected_memory_mb,
+                "Mismatch in memory_mb for {:?}",
+                variant
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_instancetype() {
+        let result = InstanceType::from_str("invalid");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        for variant in InstanceType::iter() {
+            let s = variant.to_string();
+            let parsed = InstanceType::from_str(&s).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+}

--- a/crates/kit/src/libvirt/base_disks_cli.rs
+++ b/crates/kit/src/libvirt/base_disks_cli.rs
@@ -116,6 +116,11 @@ fn run_list(connect_uri: Option<&str>, opts: ListOpts) -> Result<()> {
                 "YAML format is not supported for base-disks list command"
             ))
         }
+        OutputFormat::Xml => {
+            return Err(color_eyre::eyre::eyre!(
+                "XML format is not supported for base-disks list command"
+            ))
+        }
     }
 
     Ok(())

--- a/crates/kit/src/libvirt/list.rs
+++ b/crates/kit/src/libvirt/list.rs
@@ -143,6 +143,11 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtListOpts) 
                 "YAML format is not supported for list command"
             ))
         }
+        OutputFormat::Xml => {
+            return Err(color_eyre::eyre::eyre!(
+                "XML format is not supported for list command"
+            ))
+        }
     }
     Ok(())
 }

--- a/crates/kit/src/libvirt/mod.rs
+++ b/crates/kit/src/libvirt/mod.rs
@@ -15,6 +15,7 @@ pub enum OutputFormat {
     Table,
     Json,
     Yaml,
+    Xml,
 }
 
 /// Default memory allocation for libvirt VMs

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -174,10 +174,16 @@ pub struct LibvirtRunOpts {
     #[clap(long)]
     pub name: Option<String>,
 
+    #[clap(
+        long,
+        help = "Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides cpus/memory if specified."
+    )]
+    pub itype: Option<crate::instancetypes::InstanceType>,
+
     #[clap(flatten)]
     pub memory: MemoryOpts,
 
-    /// Number of virtual CPUs for the VM
+    /// Number of virtual CPUs for the VM (overridden by --itype if specified)
     #[clap(long, default_value = "2")]
     pub cpus: u32,
 
@@ -263,6 +269,24 @@ impl LibvirtRunOpts {
         }
         Ok(())
     }
+
+    /// Get resolved memory in MB, using instancetype if specified
+    pub fn resolved_memory_mb(&self) -> Result<u32> {
+        if let Some(itype) = self.itype {
+            Ok(itype.memory_mb())
+        } else {
+            parse_memory_to_mb(&self.memory.memory)
+        }
+    }
+
+    /// Get resolved CPU count, using instancetype if specified
+    pub fn resolved_cpus(&self) -> Result<u32> {
+        if let Some(itype) = self.itype {
+            Ok(itype.vcpus())
+        } else {
+            Ok(self.cpus)
+        }
+    }
 }
 
 /// Execute the libvirt run command
@@ -334,11 +358,17 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtRunOpts) -
 
     // VM is now managed by libvirt, no need to track separately
 
+    let resolved_memory = opts.resolved_memory_mb()?;
+    let resolved_cpus = opts.resolved_cpus()?;
+
     println!("VM '{}' created successfully!", vm_name);
     println!("  Image: {}", opts.image);
     println!("  Disk: {}", disk_path);
-    println!("  Memory: {}", opts.memory.memory);
-    println!("  CPUs: {}", opts.cpus);
+    if let Some(ref itype) = opts.itype {
+        println!("  Instance Type: {}", itype);
+    }
+    println!("  Memory: {} MiB", resolved_memory);
+    println!("  CPUs: {}", resolved_cpus);
 
     // Display volume mount information if any
     if !opts.raw_volumes.is_empty() {
@@ -924,7 +954,8 @@ fn create_libvirt_domain_from_disk(
     // Generate SMBIOS credentials for storage opts unit (handles /etc/environment for PAM/SSH)
     let storage_opts_creds = crate::sshcred::smbios_creds_for_storage_opts()?;
 
-    let memory = parse_memory_to_mb(&opts.memory.memory)?;
+    let memory = opts.resolved_memory_mb()?;
+    let cpus = opts.resolved_cpus()?;
 
     // Setup secure boot if requested
     let secure_boot_config = if let Some(keys) = opts.secure_boot_keys.as_deref() {
@@ -943,15 +974,15 @@ fn create_libvirt_domain_from_disk(
     let mut domain_builder = DomainBuilder::new()
         .with_name(domain_name)
         .with_memory(memory.into())
-        .with_vcpus(opts.cpus)
+        .with_vcpus(cpus)
         .with_disk(disk_path.as_str())
         .with_transient_disk(opts.transient)
         .with_network("none") // Use QEMU args for SSH networking instead
         .with_firmware(opts.firmware)
         .with_tpm(!opts.disable_tpm)
         .with_metadata("bootc:source-image", &opts.image)
-        .with_metadata("bootc:memory-mb", &opts.memory.to_string())
-        .with_metadata("bootc:vcpus", &opts.cpus.to_string())
+        .with_metadata("bootc:memory-mb", &memory.to_string())
+        .with_metadata("bootc:vcpus", &cpus.to_string())
         .with_metadata("bootc:disk-size-gb", &opts.disk_size.to_string())
         .with_metadata(
             "bootc:filesystem",
@@ -965,6 +996,11 @@ fn create_libvirt_domain_from_disk(
         .with_metadata("bootc:ssh-private-key-base64", &private_key_base64)
         .with_metadata("bootc:ssh-port", &ssh_port.to_string())
         .with_metadata("bootc:image-digest", image_digest);
+
+    // Add instance type metadata if specified
+    if let Some(itype) = opts.itype {
+        domain_builder = domain_builder.with_metadata("bootc:instance-type", &itype.to_string());
+    }
 
     // Add labels if specified
     if !opts.label.is_empty() {

--- a/crates/kit/src/main.rs
+++ b/crates/kit/src/main.rs
@@ -19,6 +19,7 @@ mod ephemeral;
 mod hostexec;
 mod images;
 mod install_options;
+mod instancetypes;
 mod libvirt;
 mod libvirt_upload_disk;
 #[allow(dead_code)]

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -166,10 +166,16 @@ pub struct CommonPodmanOptions {
 /// Common VM configuration options for hardware, networking, and features.
 #[derive(Parser, Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommonVmOpts {
+    #[clap(
+        long,
+        help = "Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides vcpus/memory if specified."
+    )]
+    pub itype: Option<crate::instancetypes::InstanceType>,
+
     #[clap(flatten)]
     pub memory: MemoryOpts,
 
-    #[clap(long, help = "Number of vCPUs")]
+    #[clap(long, help = "Number of vCPUs (overridden by --itype if specified)")]
     pub vcpus: Option<u32>,
 
     #[clap(long, help = "Enable console output to terminal for debugging")]
@@ -203,14 +209,22 @@ pub struct CommonVmOpts {
 }
 
 impl CommonVmOpts {
-    /// Parse memory specification to MB
+    /// Parse memory specification to MB, using instancetype if specified
     pub fn memory_mb(&self) -> color_eyre::Result<u32> {
-        crate::utils::parse_memory_to_mb(&self.memory.memory)
+        if let Some(itype) = self.itype {
+            Ok(itype.memory_mb())
+        } else {
+            crate::utils::parse_memory_to_mb(&self.memory.memory)
+        }
     }
 
-    /// Get vCPU count
-    pub fn vcpus(&self) -> u32 {
-        self.vcpus.unwrap_or_else(default_vcpus)
+    /// Get vCPU count, using instancetype if specified
+    pub fn vcpus(&self) -> color_eyre::Result<u32> {
+        if let Some(itype) = self.itype {
+            Ok(itype.vcpus())
+        } else {
+            Ok(self.vcpus.unwrap_or_else(default_vcpus))
+        }
     }
 }
 
@@ -988,7 +1002,7 @@ StandardOutput=file:/dev/virtio-ports/executestatus
     // Configure qemu
     let mut qemu_config = crate::qemu::QemuConfig::new_direct_boot(
         opts.common.memory_mb()?,
-        opts.common.vcpus(),
+        opts.common.vcpus()?,
         "/run/qemu/kernel".to_string(),
         "/run/qemu/initramfs".to_string(),
         main_virtiofsd_config.socket_path.clone(),

--- a/docs/src/man/bcvk-ephemeral-run-ssh.md
+++ b/docs/src/man/bcvk-ephemeral-run-ssh.md
@@ -23,6 +23,10 @@ Run ephemeral VM and SSH into it
 
     SSH command to execute (optional, defaults to interactive shell)
 
+**--itype**=*ITYPE*
+
+    Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides vcpus/memory if specified.
+
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)
@@ -31,7 +35,7 @@ Run ephemeral VM and SSH into it
 
 **--vcpus**=*VCPUS*
 
-    Number of vCPUs
+    Number of vCPUs (overridden by --itype if specified)
 
 **--console**
 

--- a/docs/src/man/bcvk-ephemeral-run.md
+++ b/docs/src/man/bcvk-ephemeral-run.md
@@ -49,6 +49,10 @@ This design allows bcvk to provide VM-like isolation and boot behavior while lev
 
     This argument is required.
 
+**--itype**=*ITYPE*
+
+    Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides vcpus/memory if specified.
+
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)
@@ -57,7 +61,7 @@ This design allows bcvk to provide VM-like isolation and boot behavior while lev
 
 **--vcpus**=*VCPUS*
 
-    Number of vCPUs
+    Number of vCPUs (overridden by --itype if specified)
 
 **--console**
 

--- a/docs/src/man/bcvk-libvirt-inspect.md
+++ b/docs/src/man/bcvk-libvirt-inspect.md
@@ -27,6 +27,7 @@ Show detailed information about a libvirt domain
     - table
     - json
     - yaml
+    - xml
 
     Default: yaml
 

--- a/docs/src/man/bcvk-libvirt-list.md
+++ b/docs/src/man/bcvk-libvirt-list.md
@@ -33,6 +33,7 @@ When using `--format=json` with a specific domain name, the output is a single J
     - table
     - json
     - yaml
+    - xml
 
     Default: table
 

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -23,6 +23,10 @@ Run a bootable container as a persistent VM
 
     Name for the VM (auto-generated if not specified)
 
+**--itype**=*ITYPE*
+
+    Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides cpus/memory if specified.
+
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)
@@ -31,7 +35,7 @@ Run a bootable container as a persistent VM
 
 **--cpus**=*CPUS*
 
-    Number of virtual CPUs for the VM
+    Number of virtual CPUs for the VM (overridden by --itype if specified)
 
     Default: 2
 

--- a/docs/src/man/bcvk-to-disk.md
+++ b/docs/src/man/bcvk-to-disk.md
@@ -69,6 +69,10 @@ The installation process:
 
     Default: raw
 
+**--itype**=*ITYPE*
+
+    Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides vcpus/memory if specified.
+
 **--memory**=*MEMORY*
 
     Memory size (e.g. 4G, 2048M, or plain number for MB)
@@ -77,7 +81,7 @@ The installation process:
 
 **--vcpus**=*VCPUS*
 
-    Number of vCPUs
+    Number of vCPUs (overridden by --itype if specified)
 
 **--console**
 


### PR DESCRIPTION
Add support for KubeVirt common-instancetypes to provide standardized VM sizing. Basically it's annoying to have to specify cpus and memory separately always since they're often *related*, and that's the whole idea of the generic instance type.

We only expose the U1 (Universal) series instancetype definitions from kubevirt/common-instancetypes because we're not a true cloud.

Both `bcvk ephemeral run` and `bcvk libvirt run` now accept an `--itype` flag that overrides `--vcpus` and `--memory` settings, making it easier to create consistently-sized VMs across different environments.

For libvirt VMs, the instance type is stored in domain metadata as `bootc:instance-type` for reference.

Assisted-by: Claude Code (Sonnet 4.5)