### PR TITLE
tests: Add parameterized integration test infrastructure

### DIFF
--- a/crates/integration-tests/src/tests/to_disk.rs
+++ b/crates/integration-tests/src/tests/to_disk.rs
@@ -20,7 +20,7 @@ use linkme::distributed_slice;
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::{run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
+use crate::{get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
 
 #[distributed_slice(INTEGRATION_TESTS)]
 static TEST_TO_DISK: IntegrationTest = IntegrationTest::new("to_disk", test_to_disk);
@@ -35,7 +35,7 @@ fn test_to_disk() -> Result<()> {
         "to-disk",
         "--label",
         INTEGRATION_TEST_LABEL,
-        "quay.io/centos-bootc/centos-bootc:stream10",
+        &get_test_image(),
         disk_path.as_str(),
     ])?;
 
@@ -104,7 +104,7 @@ fn test_to_disk_qcow2() -> Result<()> {
         "--format=qcow2",
         "--label",
         INTEGRATION_TEST_LABEL,
-        "quay.io/centos-bootc/centos-bootc:stream10",
+        &get_test_image(),
         disk_path.as_str(),
     ])?;
 
@@ -162,7 +162,7 @@ fn test_to_disk_caching() -> Result<()> {
         "to-disk",
         "--label",
         INTEGRATION_TEST_LABEL,
-        "quay.io/centos-bootc/centos-bootc:stream10",
+        &get_test_image(),
         disk_path.as_str(),
     ])?;
 
@@ -189,7 +189,7 @@ fn test_to_disk_caching() -> Result<()> {
         "to-disk",
         "--label",
         INTEGRATION_TEST_LABEL,
-        "quay.io/centos-bootc/centos-bootc:stream10",
+        &get_test_image(),
         disk_path.as_str(),
     ])?;
 


### PR DESCRIPTION
This introduces a matrix-based testing approach for integration tests that need to run against multiple container images. Instead of hardcoding specific images or manually creating variants for each distribution, tests can now register as parameterized tests and automatically run once per image in BCVK_ALL_IMAGES.

This enables systematic cross-distribution testing without code duplication and makes it easy to add or change the test matrix by updating environment variables rather than modifying test code.

Assisted-by: Claude Code (Sonnet 4.5)