### PR TITLE
install: Rename composefs-native -> composefs-backend

### DIFF
--- a/crates/kit/src/cache_metadata.rs
+++ b/crates/kit/src/cache_metadata.rs
@@ -37,7 +37,7 @@ struct CacheInputs {
     root_size: Option<String>,
 
     /// Whether to use composefs-native storage
-    composefs_native: bool,
+    composefs_backend: bool,
 
     /// Kernel arguments used during installation
     kernel_args: Vec<String>,
@@ -59,7 +59,7 @@ pub struct DiskImageMetadata {
     pub root_size: Option<String>,
 
     /// Whether to use composefs-native storage
-    pub composefs_native: bool,
+    pub composefs_backend: bool,
 
     /// Kernel arguments used during installation
     pub kernel_args: Vec<String>,
@@ -75,7 +75,7 @@ impl DiskImageMetadata {
             image_digest: self.digest.clone(),
             filesystem: self.filesystem.clone(),
             root_size: self.root_size.clone(),
-            composefs_native: self.composefs_native,
+            composefs_backend: self.composefs_backend,
             kernel_args: self.kernel_args.clone(),
             version: self.version,
         };
@@ -160,7 +160,7 @@ impl DiskImageMetadata {
             filesystem: options.filesystem.clone(),
             root_size: options.root_size.clone(),
             kernel_args: options.karg.clone(),
-            composefs_native: options.composefs_native,
+            composefs_backend: options.composefs_backend,
         }
     }
 }
@@ -291,7 +291,7 @@ mod tests {
             filesystem: Some("ext4".to_string()),
             root_size: Some("20G".to_string()),
             kernel_args: vec!["console=ttyS0".to_string()],
-            composefs_native: false,
+            composefs_backend: false,
             version: 1,
         };
 

--- a/crates/kit/src/install_options.rs
+++ b/crates/kit/src/install_options.rs
@@ -35,7 +35,7 @@ pub struct InstallOptions {
 
     /// Default to composefs-native storage
     #[clap(long)]
-    pub composefs_native: bool,
+    pub composefs_backend: bool,
 }
 
 impl InstallOptions {
@@ -57,8 +57,8 @@ impl InstallOptions {
             args.push(format!("--karg={k}"));
         }
 
-        if self.composefs_native {
-            args.push("--composefs-native".to_owned());
+        if self.composefs_backend {
+            args.push("--composefs-backend".to_owned());
         }
 
         args

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -57,7 +57,7 @@ Run a bootable container as a persistent VM
 
     Set a kernel argument
 
-**--composefs-native**
+**--composefs-backend**
 
     Default to composefs-native storage
 

--- a/docs/src/man/bcvk-libvirt-upload.md
+++ b/docs/src/man/bcvk-libvirt-upload.md
@@ -49,7 +49,7 @@ Upload bootc disk images to libvirt with metadata annotations
 
     Set a kernel argument
 
-**--composefs-native**
+**--composefs-backend**
 
     Default to composefs-native storage
 

--- a/docs/src/man/bcvk-to-disk.md
+++ b/docs/src/man/bcvk-to-disk.md
@@ -51,7 +51,7 @@ The installation process:
 
     Set a kernel argument
 
-**--composefs-native**
+**--composefs-backend**
 
     Default to composefs-native storage
 


### PR DESCRIPTION
This is how the option is called in latest bootc.

Closes: https://github.com/bootc-dev/bcvk/issues/117