### PR TITLE
libvirt: Downgrade some duplicate logging

### DIFF
--- a/crates/kit/src/cache_metadata.rs
+++ b/crates/kit/src/cache_metadata.rs
@@ -213,7 +213,7 @@ pub fn check_cached_disk(
 
     let matches = expected_hash == cached_hash;
     if matches {
-        tracing::info!(
+        tracing::debug!(
             "Found cached disk image at {:?} matching cache hash {}",
             path,
             expected_hash

--- a/crates/kit/src/libvirt/base_disks.rs
+++ b/crates/kit/src/libvirt/base_disks.rs
@@ -47,7 +47,6 @@ pub fn find_or_create_base_disk(
         )?
         .is_ok()
         {
-            info!("Found cached base disk: {:?}", base_disk_path);
             return Ok(base_disk_path);
         } else {
             info!("Base disk exists but metadata doesn't match, will recreate");
@@ -238,7 +237,7 @@ pub fn clone_from_base(
             .with_context(|| format!("Failed to remove disk file: {:?}", vm_disk_path))?;
     }
 
-    info!(
+    debug!(
         "Creating VM disk with backing file: {:?} -> {:?}",
         base_disk_path, vm_disk_path
     );
@@ -279,7 +278,7 @@ pub fn clone_from_base(
         ));
     }
 
-    info!(
+    debug!(
         "Successfully created VM disk with backing file: {:?}",
         vm_disk_path
     );


### PR DESCRIPTION
We were too verbose by default here.