### PR TITLE
integration-tests: Add macro to reduce test registration boilerplate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,7 @@ dependencies = [
  "dirs",
  "libtest-mimic",
  "linkme",
+ "paste",
  "regex",
  "serde",
  "serde_json",
@@ -1773,6 +1774,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { version = "1.18.1", features = ["v4"] }
 camino = "1.1.12"
 regex = "1"
 linkme = "0.3.30"
+paste = "1.0"
 
 [lints]
 workspace = true

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -60,6 +60,56 @@ pub static INTEGRATION_TESTS: [IntegrationTest];
 #[distributed_slice]
 pub static PARAMETERIZED_INTEGRATION_TESTS: [ParameterizedIntegrationTest];
 
+/// Register an integration test with less boilerplate.
+///
+/// This macro generates the static registration for an integration test function.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn test_basic_functionality() -> Result<()> {
+///     let output = run_bcvk(&["some", "args"])?;
+///     output.assert_success("test");
+///     Ok(())
+/// }
+/// integration_test!(test_basic_functionality);
+/// ```
+#[macro_export]
+macro_rules! integration_test {
+    ($fn_name:ident) => {
+        ::paste::paste! {
+            #[distributed_slice($crate::INTEGRATION_TESTS)]
+            static [<$fn_name:upper>]: $crate::IntegrationTest =
+                $crate::IntegrationTest::new(stringify!($fn_name), $fn_name);
+        }
+    };
+}
+
+/// Register a parameterized integration test with less boilerplate.
+///
+/// This macro generates the static registration for a parameterized integration test function.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn test_with_image(image: &str) -> Result<()> {
+///     let output = run_bcvk(&["command", image])?;
+///     output.assert_success("test");
+///     Ok(())
+/// }
+/// parameterized_integration_test!(test_with_image);
+/// ```
+#[macro_export]
+macro_rules! parameterized_integration_test {
+    ($fn_name:ident) => {
+        ::paste::paste! {
+            #[distributed_slice($crate::PARAMETERIZED_INTEGRATION_TESTS)]
+            static [<$fn_name:upper>]: $crate::ParameterizedIntegrationTest =
+                $crate::ParameterizedIntegrationTest::new(stringify!($fn_name), $fn_name);
+        }
+    };
+}
+
 /// Create a test suffix from an image name by replacing invalid characters with underscores
 ///
 /// Replaces all non-alphanumeric characters with `_` to create a predictable, filesystem-safe

--- a/crates/integration-tests/src/tests/libvirt_base_disks.rs
+++ b/crates/integration-tests/src/tests/libvirt_base_disks.rs
@@ -7,17 +7,13 @@
 //! - base-disks prune command
 
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use regex::Regex;
 use std::process::Command;
 
-use crate::{get_bck_command, get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS};
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_BASE_DISK_CREATION_AND_REUSE: IntegrationTest = IntegrationTest::new(
-    "test_base_disk_creation_and_reuse",
-    test_base_disk_creation_and_reuse,
-);
+use crate::{get_bck_command, get_test_image, run_bcvk};
 
 /// Test that base disk is created and reused for multiple VMs
 fn test_base_disk_creation_and_reuse() -> Result<()> {
@@ -99,10 +95,7 @@ fn test_base_disk_creation_and_reuse() -> Result<()> {
     println!("✓ Base disk creation and reuse test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_BASE_DISKS_LIST_COMMAND: IntegrationTest =
-    IntegrationTest::new("test_base_disks_list_command", test_base_disks_list_command);
+integration_test!(test_base_disk_creation_and_reuse);
 
 /// Test base-disks list command
 fn test_base_disks_list_command() -> Result<()> {
@@ -143,12 +136,7 @@ fn test_base_disks_list_command() -> Result<()> {
     }
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_BASE_DISKS_LIST_SHOWS_TIMESTAMP: IntegrationTest = IntegrationTest::new(
-    "test_base_disks_list_shows_timestamp",
-    test_base_disks_list_shows_timestamp,
-);
+integration_test!(test_base_disks_list_command);
 
 /// Test base-disks list shows creation timestamp
 fn test_base_disks_list_shows_timestamp() -> Result<()> {
@@ -218,12 +206,7 @@ fn test_base_disks_list_shows_timestamp() -> Result<()> {
     }
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_BASE_DISKS_PRUNE_DRY_RUN: IntegrationTest = IntegrationTest::new(
-    "test_base_disks_prune_dry_run",
-    test_base_disks_prune_dry_run,
-);
+integration_test!(test_base_disks_list_shows_timestamp);
 
 /// Test base-disks prune command with dry-run
 fn test_base_disks_prune_dry_run() -> Result<()> {
@@ -260,10 +243,7 @@ fn test_base_disks_prune_dry_run() -> Result<()> {
     }
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_VM_DISK_REFERENCES_BASE: IntegrationTest =
-    IntegrationTest::new("test_vm_disk_references_base", test_vm_disk_references_base);
+integration_test!(test_base_disks_prune_dry_run);
 
 /// Test that VM disks reference base disks correctly
 fn test_vm_disk_references_base() -> Result<()> {
@@ -336,6 +316,7 @@ fn test_vm_disk_references_base() -> Result<()> {
     println!("✓ VM disk reference test passed");
     Ok(())
 }
+integration_test!(test_vm_disk_references_base);
 
 /// Helper function to cleanup domain and its disk
 fn cleanup_domain(domain_name: &str) {

--- a/crates/integration-tests/src/tests/libvirt_port_forward.rs
+++ b/crates/integration-tests/src/tests/libvirt_port_forward.rs
@@ -6,19 +6,12 @@
 //! - Actual network connectivity through forwarded ports
 
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::process::Command;
 
-use crate::{
-    get_bck_command, get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS,
-    LIBVIRT_INTEGRATION_TEST_LABEL,
-};
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_PORT_FORWARD_PARSING: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_port_forward_parsing",
-    test_libvirt_port_forward_parsing,
-);
+use crate::{get_bck_command, get_test_image, run_bcvk, LIBVIRT_INTEGRATION_TEST_LABEL};
 
 /// Test port forwarding argument parsing
 fn test_libvirt_port_forward_parsing() -> Result<()> {
@@ -63,12 +56,7 @@ fn test_libvirt_port_forward_parsing() -> Result<()> {
     println!("✓ Port forwarding argument parsing validated");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_PORT_FORWARD_INVALID: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_port_forward_invalid",
-    test_libvirt_port_forward_invalid,
-);
+integration_test!(test_libvirt_port_forward_parsing);
 
 /// Test port forwarding error handling for invalid formats
 fn test_libvirt_port_forward_invalid() -> Result<()> {
@@ -134,12 +122,7 @@ fn test_libvirt_port_forward_invalid() -> Result<()> {
     println!("✓ Port forwarding error handling validated");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_PORT_FORWARD_XML: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_port_forward_xml",
-    test_libvirt_port_forward_xml,
-);
+integration_test!(test_libvirt_port_forward_invalid);
 
 /// Test that port forwarding is correctly configured in domain XML
 fn test_libvirt_port_forward_xml() -> Result<()> {
@@ -247,12 +230,7 @@ fn test_libvirt_port_forward_xml() -> Result<()> {
     println!("✓ Port forwarding XML configuration test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_PORT_FORWARD_CONNECTIVITY: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_port_forward_connectivity",
-    test_libvirt_port_forward_connectivity,
-);
+integration_test!(test_libvirt_port_forward_xml);
 
 /// Test actual network connectivity through forwarded ports
 fn test_libvirt_port_forward_connectivity() -> Result<()> {
@@ -437,6 +415,7 @@ fn test_libvirt_port_forward_connectivity() -> Result<()> {
     println!("✓ Port forwarding connectivity test passed");
     Ok(())
 }
+integration_test!(test_libvirt_port_forward_connectivity);
 
 /// Helper function to cleanup domain
 fn cleanup_domain(domain_name: &str) {

--- a/crates/integration-tests/src/tests/libvirt_verb.rs
+++ b/crates/integration-tests/src/tests/libvirt_verb.rs
@@ -8,20 +8,15 @@
 //! - Domain lifecycle management (start/stop/rm/inspect)
 
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::process::Command;
 
 use crate::{
-    get_bck_command, get_test_image, run_bcvk, run_bcvk_nocapture, IntegrationTest,
-    INTEGRATION_TESTS, LIBVIRT_INTEGRATION_TEST_LABEL,
+    get_bck_command, get_test_image, run_bcvk, run_bcvk_nocapture, LIBVIRT_INTEGRATION_TEST_LABEL,
 };
 use bcvk::xml_utils::parse_xml_dom;
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_LIST_FUNCTIONALITY: IntegrationTest = IntegrationTest::new(
-    "libvirt_list_functionality",
-    test_libvirt_list_functionality,
-);
 
 /// Test libvirt list functionality (lists domains)
 fn test_libvirt_list_functionality() -> Result<()> {
@@ -57,10 +52,7 @@ fn test_libvirt_list_functionality() -> Result<()> {
     println!("libvirt list functionality tested");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_LIST_JSON_OUTPUT: IntegrationTest =
-    IntegrationTest::new("libvirt_list_json_output", test_libvirt_list_json_output);
+integration_test!(test_libvirt_list_functionality);
 
 /// Test libvirt list with JSON output
 fn test_libvirt_list_json_output() -> Result<()> {
@@ -94,12 +86,7 @@ fn test_libvirt_list_json_output() -> Result<()> {
     println!("libvirt list JSON output tested");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_LIST_JSON_SSH_METADATA: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_list_json_ssh_metadata",
-    test_libvirt_run_list_json_ssh_metadata,
-);
+integration_test!(test_libvirt_list_json_output);
 
 /// Test libvirt list JSON output includes SSH metadata
 fn test_libvirt_run_list_json_ssh_metadata() -> Result<()> {
@@ -235,12 +222,7 @@ fn test_libvirt_run_list_json_ssh_metadata() -> Result<()> {
     println!("✓ libvirt list JSON SSH metadata test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_RESOURCE_OPTIONS: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_resource_options",
-    test_libvirt_run_resource_options,
-);
+integration_test!(test_libvirt_run_list_json_ssh_metadata);
 
 /// Test domain resource configuration options
 fn test_libvirt_run_resource_options() -> Result<()> {
@@ -285,10 +267,7 @@ fn test_libvirt_run_resource_options() -> Result<()> {
     println!("libvirt run resource options validated");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_NETWORKING: IntegrationTest =
-    IntegrationTest::new("test_libvirt_run_networking", test_libvirt_run_networking);
+integration_test!(test_libvirt_run_resource_options);
 
 /// Test domain networking configuration
 fn test_libvirt_run_networking() -> Result<()> {
@@ -332,10 +311,7 @@ fn test_libvirt_run_networking() -> Result<()> {
     println!("libvirt run networking options validated");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_SSH_INTEGRATION: IntegrationTest =
-    IntegrationTest::new("test_libvirt_ssh_integration", test_libvirt_ssh_integration);
+integration_test!(test_libvirt_run_networking);
 
 /// Test SSH integration with created domains (syntax only)
 fn test_libvirt_ssh_integration() -> Result<()> {
@@ -362,12 +338,7 @@ fn test_libvirt_ssh_integration() -> Result<()> {
     println!("libvirt SSH integration tested");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_WITH_INSTANCETYPE: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_with_instancetype",
-    test_libvirt_run_with_instancetype,
-);
+integration_test!(test_libvirt_ssh_integration);
 
 /// Test libvirt run with instancetype
 fn test_libvirt_run_with_instancetype() -> Result<()> {
@@ -453,6 +424,7 @@ fn test_libvirt_run_with_instancetype() -> Result<()> {
     println!("✓ libvirt run with instancetype test passed");
     Ok(())
 }
+integration_test!(test_libvirt_run_with_instancetype);
 
 /// Helper function to cleanup domain
 fn cleanup_domain(domain_name: &str) {
@@ -553,12 +525,6 @@ fn wait_for_ssh_available(
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_VM_LIFECYCLE: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_vm_lifecycle",
-    test_libvirt_run_vm_lifecycle,
-);
 
 /// Test VM startup and shutdown with libvirt run
 fn test_libvirt_run_vm_lifecycle() -> Result<()> {
@@ -661,12 +627,7 @@ fn test_libvirt_run_vm_lifecycle() -> Result<()> {
     println!("VM lifecycle test completed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_BIND_STORAGE_RO: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_bind_storage_ro",
-    test_libvirt_run_bind_storage_ro,
-);
+integration_test!(test_libvirt_run_vm_lifecycle);
 
 /// Test container storage binding functionality end-to-end
 fn test_libvirt_run_bind_storage_ro() -> Result<()> {
@@ -818,12 +779,7 @@ fn test_libvirt_run_bind_storage_ro() -> Result<()> {
     println!("✓ --bind-storage-ro end-to-end test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_LABEL_FUNCTIONALITY: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_label_functionality",
-    test_libvirt_run_label_functionality,
-);
+integration_test!(test_libvirt_run_bind_storage_ro);
 
 /// Test libvirt label functionality
 fn test_libvirt_run_label_functionality() -> Result<()> {
@@ -954,13 +910,7 @@ fn test_libvirt_run_label_functionality() -> Result<()> {
     println!("✓ Label functionality test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_NO_STORAGE_OPTS_WITHOUT_BIND_STORAGE: IntegrationTest =
-    IntegrationTest::new(
-        "test_libvirt_run_no_storage_opts_without_bind_storage",
-        test_libvirt_run_no_storage_opts_without_bind_storage,
-    );
+integration_test!(test_libvirt_run_label_functionality);
 
 /// Test that STORAGE_OPTS credentials are NOT injected when --bind-storage-ro is not used
 fn test_libvirt_run_no_storage_opts_without_bind_storage() -> Result<()> {
@@ -1064,10 +1014,7 @@ fn test_libvirt_run_no_storage_opts_without_bind_storage() -> Result<()> {
     println!("✓ Test passed: STORAGE_OPTS credentials are correctly excluded when --bind-storage-ro is not used");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_ERROR_HANDLING: IntegrationTest =
-    IntegrationTest::new("test_libvirt_error_handling", test_libvirt_error_handling);
+integration_test!(test_libvirt_run_no_storage_opts_without_bind_storage);
 
 /// Test error handling for invalid configurations
 fn test_libvirt_error_handling() -> Result<()> {
@@ -1109,12 +1056,7 @@ fn test_libvirt_error_handling() -> Result<()> {
     println!("libvirt error handling validated");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_TRANSIENT_VM: IntegrationTest = IntegrationTest::new(
-    "test_libvirt_run_transient_vm",
-    test_libvirt_run_transient_vm,
-);
+integration_test!(test_libvirt_error_handling);
 
 /// Test transient VM functionality
 fn test_libvirt_run_transient_vm() -> Result<()> {
@@ -1270,10 +1212,7 @@ fn test_libvirt_run_transient_vm() -> Result<()> {
     println!("✓ Transient VM test passed");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_LIBVIRT_RUN_BIND_MOUNTS: IntegrationTest =
-    IntegrationTest::new("test_libvirt_run_bind_mounts", test_libvirt_run_bind_mounts);
+integration_test!(test_libvirt_run_transient_vm);
 
 /// Test automatic bind mount functionality with systemd mount units
 /// Also validates kernel argument (--karg) functionality
@@ -1542,3 +1481,4 @@ fn test_libvirt_run_bind_mounts() -> Result<()> {
     println!("✓ Bind mounts and karg test passed");
     Ok(())
 }
+integration_test!(test_libvirt_run_bind_mounts);

--- a/crates/integration-tests/src/tests/mount_feature.rs
+++ b/crates/integration-tests/src/tests/mount_feature.rs
@@ -16,11 +16,13 @@
 
 use camino::Utf8Path;
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::fs;
 use tempfile::TempDir;
 
-use crate::{get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
+use crate::{get_test_image, run_bcvk, INTEGRATION_TEST_LABEL};
 
 /// Create a systemd unit that verifies a mount exists and tests writability
 fn create_mount_verify_unit(
@@ -67,10 +69,6 @@ StandardError=journal+console
     fs::write(&unit_path, unit_content)?;
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_MOUNT_FEATURE_BIND: IntegrationTest =
-    IntegrationTest::new("mount_feature_bind", test_mount_feature_bind);
 
 fn test_mount_feature_bind() -> Result<()> {
     // Create a temporary directory to test bind mounting
@@ -123,10 +121,7 @@ fn test_mount_feature_bind() -> Result<()> {
     println!("Successfully tested and verified bind mount feature");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_MOUNT_FEATURE_RO_BIND: IntegrationTest =
-    IntegrationTest::new("mount_feature_ro_bind", test_mount_feature_ro_bind);
+integration_test!(test_mount_feature_bind);
 
 fn test_mount_feature_ro_bind() -> Result<()> {
     // Create a temporary directory to test read-only bind mounting
@@ -173,3 +168,4 @@ fn test_mount_feature_ro_bind() -> Result<()> {
     assert!(output.stdout.contains("ok mount verify"));
     Ok(())
 }
+integration_test!(test_mount_feature_ro_bind);

--- a/crates/integration-tests/src/tests/run_ephemeral.rs
+++ b/crates/integration-tests/src/tests/run_ephemeral.rs
@@ -15,11 +15,13 @@
 //! - Warning and continuing on failures
 
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::process::Command;
 use tracing::debug;
 
-use crate::{get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
+use crate::{get_test_image, run_bcvk, INTEGRATION_TEST_LABEL};
 
 pub fn get_container_kernel_version(image: &str) -> String {
     // Run container to get its kernel version
@@ -44,12 +46,6 @@ pub fn get_container_kernel_version(image: &str) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_CORRECT_KERNEL: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_correct_kernel",
-    test_run_ephemeral_correct_kernel,
-);
-
 fn test_run_ephemeral_correct_kernel() -> Result<()> {
     let image = get_test_image();
     let container_kernel = get_container_kernel_version(&image);
@@ -69,10 +65,7 @@ fn test_run_ephemeral_correct_kernel() -> Result<()> {
     output.assert_success("ephemeral run");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_POWEROFF: IntegrationTest =
-    IntegrationTest::new("run_ephemeral_poweroff", test_run_ephemeral_poweroff);
+integration_test!(test_run_ephemeral_correct_kernel);
 
 fn test_run_ephemeral_poweroff() -> Result<()> {
     let output = run_bcvk(&[
@@ -89,12 +82,7 @@ fn test_run_ephemeral_poweroff() -> Result<()> {
     output.assert_success("ephemeral run");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_WITH_MEMORY_LIMIT: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_with_memory_limit",
-    test_run_ephemeral_with_memory_limit,
-);
+integration_test!(test_run_ephemeral_poweroff);
 
 fn test_run_ephemeral_with_memory_limit() -> Result<()> {
     let output = run_bcvk(&[
@@ -113,10 +101,7 @@ fn test_run_ephemeral_with_memory_limit() -> Result<()> {
     output.assert_success("ephemeral run with memory limit");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_WITH_VCPUS: IntegrationTest =
-    IntegrationTest::new("run_ephemeral_with_vcpus", test_run_ephemeral_with_vcpus);
+integration_test!(test_run_ephemeral_with_memory_limit);
 
 fn test_run_ephemeral_with_vcpus() -> Result<()> {
     let output = run_bcvk(&[
@@ -135,10 +120,7 @@ fn test_run_ephemeral_with_vcpus() -> Result<()> {
     output.assert_success("ephemeral run with vcpus");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_EXECUTE: IntegrationTest =
-    IntegrationTest::new("run_ephemeral_execute", test_run_ephemeral_execute);
+integration_test!(test_run_ephemeral_with_vcpus);
 
 fn test_run_ephemeral_execute() -> Result<()> {
     let script =
@@ -176,12 +158,7 @@ fn test_run_ephemeral_execute() -> Result<()> {
     );
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_CONTAINER_SSH_ACCESS: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_container_ssh_access",
-    test_run_ephemeral_container_ssh_access,
-);
+integration_test!(test_run_ephemeral_execute);
 
 fn test_run_ephemeral_container_ssh_access() -> Result<()> {
     let image = get_test_image();
@@ -228,12 +205,7 @@ fn test_run_ephemeral_container_ssh_access() -> Result<()> {
     assert!(ssh_output.stdout.contains("SSH_TEST_SUCCESS"));
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_WITH_INSTANCETYPE: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_with_instancetype",
-    test_run_ephemeral_with_instancetype,
-);
+integration_test!(test_run_ephemeral_container_ssh_access);
 
 fn test_run_ephemeral_with_instancetype() -> Result<()> {
     // Test u1.nano: 1 vCPU, 512 MiB memory
@@ -296,12 +268,7 @@ fn test_run_ephemeral_with_instancetype() -> Result<()> {
 
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_INSTANCETYPE_INVALID: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_instancetype_invalid",
-    test_run_ephemeral_instancetype_invalid,
-);
+integration_test!(test_run_ephemeral_with_instancetype);
 
 fn test_run_ephemeral_instancetype_invalid() -> Result<()> {
     let output = run_bcvk(&[
@@ -332,3 +299,4 @@ fn test_run_ephemeral_instancetype_invalid() -> Result<()> {
 
     Ok(())
 }
+integration_test!(test_run_ephemeral_instancetype_invalid);

--- a/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
+++ b/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
@@ -15,19 +15,17 @@
 //! - Warning and continuing on failures
 
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
 use crate::{
-    get_test_image, run_bcvk, IntegrationTest, ParameterizedIntegrationTest, INTEGRATION_TESTS,
-    INTEGRATION_TEST_LABEL, PARAMETERIZED_INTEGRATION_TESTS,
+    get_test_image, run_bcvk, ParameterizedIntegrationTest, INTEGRATION_TEST_LABEL,
+    PARAMETERIZED_INTEGRATION_TESTS,
 };
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_SSH_COMMAND: IntegrationTest =
-    IntegrationTest::new("run_ephemeral_ssh_command", test_run_ephemeral_ssh_command);
 
 /// Test running a non-interactive command via SSH
 fn test_run_ephemeral_ssh_command() -> Result<()> {
@@ -51,10 +49,7 @@ fn test_run_ephemeral_ssh_command() -> Result<()> {
     );
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_SSH_CLEANUP: IntegrationTest =
-    IntegrationTest::new("run_ephemeral_ssh_cleanup", test_run_ephemeral_ssh_cleanup);
+integration_test!(test_run_ephemeral_ssh_command);
 
 /// Test that the container is cleaned up when SSH exits
 fn test_run_ephemeral_ssh_cleanup() -> Result<()> {
@@ -91,12 +86,7 @@ fn test_run_ephemeral_ssh_cleanup() -> Result<()> {
     );
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_SSH_SYSTEM_COMMAND: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_ssh_system_command",
-    test_run_ephemeral_ssh_system_command,
-);
+integration_test!(test_run_ephemeral_ssh_cleanup);
 
 /// Test running system commands via SSH
 fn test_run_ephemeral_ssh_system_command() -> Result<()> {
@@ -115,12 +105,7 @@ fn test_run_ephemeral_ssh_system_command() -> Result<()> {
     output.assert_success("ephemeral run-ssh");
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_SSH_EXIT_CODE: IntegrationTest = IntegrationTest::new(
-    "run_ephemeral_ssh_exit_code",
-    test_run_ephemeral_ssh_exit_code,
-);
+integration_test!(test_run_ephemeral_ssh_system_command);
 
 /// Test that ephemeral run-ssh properly forwards exit codes
 fn test_run_ephemeral_ssh_exit_code() -> Result<()> {
@@ -143,6 +128,7 @@ fn test_run_ephemeral_ssh_exit_code() -> Result<()> {
     );
     Ok(())
 }
+integration_test!(test_run_ephemeral_ssh_exit_code);
 
 #[distributed_slice(PARAMETERIZED_INTEGRATION_TESTS)]
 static TEST_RUN_EPHEMERAL_SSH_CROSS_DISTRO_COMPATIBILITY: ParameterizedIntegrationTest =
@@ -204,9 +190,6 @@ fn test_run_ephemeral_ssh_cross_distro_compatibility(image: &str) -> Result<()> 
     }
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_RUN_TMPFS: IntegrationTest = IntegrationTest::new("run_tmpfs", test_run_tmpfs);
 
 /// Test that /run is mounted as tmpfs and supports unix domain sockets
 fn test_run_tmpfs() -> Result<()> {
@@ -274,3 +257,4 @@ echo "All checks passed!"
 
     Ok(())
 }
+integration_test!(test_run_tmpfs);

--- a/crates/integration-tests/src/tests/to_disk.rs
+++ b/crates/integration-tests/src/tests/to_disk.rs
@@ -16,14 +16,13 @@
 
 use camino::Utf8PathBuf;
 use color_eyre::Result;
+use integration_tests::integration_test;
 use linkme::distributed_slice;
+
 use std::process::Command;
 use tempfile::TempDir;
 
-use crate::{get_test_image, run_bcvk, IntegrationTest, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL};
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_TO_DISK: IntegrationTest = IntegrationTest::new("to_disk", test_to_disk);
+use crate::{get_test_image, run_bcvk, INTEGRATION_TEST_LABEL};
 
 /// Test actual bootc installation to a disk image
 fn test_to_disk() -> Result<()> {
@@ -88,10 +87,7 @@ fn test_to_disk() -> Result<()> {
     );
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_TO_DISK_QCOW2: IntegrationTest =
-    IntegrationTest::new("to_disk_qcow2", test_to_disk_qcow2);
+integration_test!(test_to_disk);
 
 /// Test bootc installation to a qcow2 disk image
 fn test_to_disk_qcow2() -> Result<()> {
@@ -146,10 +142,7 @@ fn test_to_disk_qcow2() -> Result<()> {
     );
     Ok(())
 }
-
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_TO_DISK_CACHING: IntegrationTest =
-    IntegrationTest::new("to_disk_caching", test_to_disk_caching);
+integration_test!(test_to_disk_qcow2);
 
 /// Test disk image caching functionality
 fn test_to_disk_caching() -> Result<()> {
@@ -221,3 +214,4 @@ fn test_to_disk_caching() -> Result<()> {
     );
     Ok(())
 }
+integration_test!(test_to_disk_caching);


### PR DESCRIPTION
The goal is to reduce boilerplate.

Assisted-by: Claude Code (Sonnet 4.5)