### PR TITLE
integration-tests: Fully qualify distributed_slice in macros

### DIFF
--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -6,8 +6,6 @@
 // Unfortunately needed here to work with linkme
 #![allow(unsafe_code)]
 
-use linkme::distributed_slice;
-
 /// Label used to identify containers created by integration tests
 pub const INTEGRATION_TEST_LABEL: &str = "bcvk.integration-test=1";
 
@@ -53,11 +51,11 @@ impl ParameterizedIntegrationTest {
 }
 
 /// Distributed slice holding all registered integration tests
-#[distributed_slice]
+#[linkme::distributed_slice]
 pub static INTEGRATION_TESTS: [IntegrationTest];
 
 /// Distributed slice holding all registered parameterized integration tests
-#[distributed_slice]
+#[linkme::distributed_slice]
 pub static PARAMETERIZED_INTEGRATION_TESTS: [ParameterizedIntegrationTest];
 
 /// Register an integration test with less boilerplate.
@@ -78,7 +76,7 @@ pub static PARAMETERIZED_INTEGRATION_TESTS: [ParameterizedIntegrationTest];
 macro_rules! integration_test {
     ($fn_name:ident) => {
         ::paste::paste! {
-            #[distributed_slice($crate::INTEGRATION_TESTS)]
+            #[::linkme::distributed_slice($crate::INTEGRATION_TESTS)]
             static [<$fn_name:upper>]: $crate::IntegrationTest =
                 $crate::IntegrationTest::new(stringify!($fn_name), $fn_name);
         }
@@ -103,7 +101,7 @@ macro_rules! integration_test {
 macro_rules! parameterized_integration_test {
     ($fn_name:ident) => {
         ::paste::paste! {
-            #[distributed_slice($crate::PARAMETERIZED_INTEGRATION_TESTS)]
+            #[::linkme::distributed_slice($crate::PARAMETERIZED_INTEGRATION_TESTS)]
             static [<$fn_name:upper>]: $crate::ParameterizedIntegrationTest =
                 $crate::ParameterizedIntegrationTest::new(stringify!($fn_name), $fn_name);
         }

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -11,10 +11,9 @@ use xshell::{cmd, Shell};
 
 // Re-export constants from lib for internal use
 pub(crate) use integration_tests::{
-    image_to_test_suffix, IntegrationTest, ParameterizedIntegrationTest, INTEGRATION_TESTS,
-    INTEGRATION_TEST_LABEL, LIBVIRT_INTEGRATION_TEST_LABEL, PARAMETERIZED_INTEGRATION_TESTS,
+    image_to_test_suffix, integration_test, INTEGRATION_TESTS, INTEGRATION_TEST_LABEL,
+    LIBVIRT_INTEGRATION_TEST_LABEL, PARAMETERIZED_INTEGRATION_TESTS,
 };
-use linkme::distributed_slice;
 
 mod tests {
     pub mod libvirt_base_disks;
@@ -144,9 +143,6 @@ pub(crate) fn run_bcvk_nocapture(args: &[&str]) -> std::io::Result<()> {
     Ok(())
 }
 
-#[distributed_slice(INTEGRATION_TESTS)]
-static TEST_IMAGES_LIST: IntegrationTest = IntegrationTest::new("images_list", test_images_list);
-
 fn test_images_list() -> Result<()> {
     println!("Running test: bcvk images list --json");
 
@@ -188,6 +184,7 @@ fn test_images_list() -> Result<()> {
     println!("All image entries are valid JSON objects");
     Ok(())
 }
+integration_test!(test_images_list);
 
 fn main() {
     let args = Arguments::from_args();

--- a/crates/integration-tests/src/tests/libvirt_base_disks.rs
+++ b/crates/integration-tests/src/tests/libvirt_base_disks.rs
@@ -8,7 +8,6 @@
 
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use regex::Regex;
 use std::process::Command;

--- a/crates/integration-tests/src/tests/libvirt_port_forward.rs
+++ b/crates/integration-tests/src/tests/libvirt_port_forward.rs
@@ -7,7 +7,6 @@
 
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use std::process::Command;
 

--- a/crates/integration-tests/src/tests/libvirt_verb.rs
+++ b/crates/integration-tests/src/tests/libvirt_verb.rs
@@ -9,7 +9,6 @@
 
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use std::process::Command;
 

--- a/crates/integration-tests/src/tests/mount_feature.rs
+++ b/crates/integration-tests/src/tests/mount_feature.rs
@@ -17,7 +17,6 @@
 use camino::Utf8Path;
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use std::fs;
 use tempfile::TempDir;

--- a/crates/integration-tests/src/tests/run_ephemeral.rs
+++ b/crates/integration-tests/src/tests/run_ephemeral.rs
@@ -16,7 +16,6 @@
 
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use std::process::Command;
 use tracing::debug;

--- a/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
+++ b/crates/integration-tests/src/tests/run_ephemeral_ssh.rs
@@ -15,17 +15,13 @@
 //! - Warning and continuing on failures
 
 use color_eyre::Result;
-use integration_tests::integration_test;
-use linkme::distributed_slice;
+use integration_tests::{integration_test, parameterized_integration_test};
 
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
-use crate::{
-    get_test_image, run_bcvk, ParameterizedIntegrationTest, INTEGRATION_TEST_LABEL,
-    PARAMETERIZED_INTEGRATION_TESTS,
-};
+use crate::{get_test_image, run_bcvk, INTEGRATION_TEST_LABEL};
 
 /// Test running a non-interactive command via SSH
 fn test_run_ephemeral_ssh_command() -> Result<()> {
@@ -130,13 +126,6 @@ fn test_run_ephemeral_ssh_exit_code() -> Result<()> {
 }
 integration_test!(test_run_ephemeral_ssh_exit_code);
 
-#[distributed_slice(PARAMETERIZED_INTEGRATION_TESTS)]
-static TEST_RUN_EPHEMERAL_SSH_CROSS_DISTRO_COMPATIBILITY: ParameterizedIntegrationTest =
-    ParameterizedIntegrationTest::new(
-        "run_ephemeral_ssh_cross_distro_compatibility",
-        test_run_ephemeral_ssh_cross_distro_compatibility,
-    );
-
 /// Test SSH functionality across different bootc images
 /// This parameterized test runs once per image in BCVK_ALL_IMAGES and verifies
 /// that our systemd version compatibility fix works correctly with both newer
@@ -190,6 +179,7 @@ fn test_run_ephemeral_ssh_cross_distro_compatibility(image: &str) -> Result<()> 
     }
     Ok(())
 }
+parameterized_integration_test!(test_run_ephemeral_ssh_cross_distro_compatibility);
 
 /// Test that /run is mounted as tmpfs and supports unix domain sockets
 fn test_run_tmpfs() -> Result<()> {

--- a/crates/integration-tests/src/tests/to_disk.rs
+++ b/crates/integration-tests/src/tests/to_disk.rs
@@ -17,7 +17,6 @@
 use camino::Utf8PathBuf;
 use color_eyre::Result;
 use integration_tests::integration_test;
-use linkme::distributed_slice;
 
 use std::process::Command;
 use tempfile::TempDir;


### PR DESCRIPTION
The integration_test! and parameterized_integration_test! macros now fully qualify linkme::distributed_slice, eliminating the need for test files to import it directly.

Assisted-by: Claude Code (Sonnet 4.5)