### PR TITLE
libvirt run: Add --ssh-wait flag for test integration

### DIFF
--- a/crates/kit/src/libvirt/ssh.rs
+++ b/crates/kit/src/libvirt/ssh.rs
@@ -46,6 +46,10 @@ pub struct LibvirtSshOpts {
     /// Extra SSH options in key=value format
     #[clap(long)]
     pub extra_options: Vec<String>,
+
+    /// Suppress stdout/stderr output (for connectivity testing)
+    #[clap(skip)]
+    pub suppress_output: bool,
 }
 
 /// SSH configuration extracted from domain metadata
@@ -316,13 +320,17 @@ impl LibvirtSshOpts {
                 .map_err(|e| eyre!("Failed to execute SSH command: {}", e))?;
 
             if !output.stdout.is_empty() {
-                // Forward stdout to parent process
-                print!("{}", String::from_utf8_lossy(&output.stdout));
+                if !self.suppress_output {
+                    // Forward stdout to parent process
+                    print!("{}", String::from_utf8_lossy(&output.stdout));
+                }
                 debug!("SSH stdout: {}", String::from_utf8_lossy(&output.stdout));
             }
             if !output.stderr.is_empty() {
-                // Forward stderr to parent process
-                eprint!("{}", String::from_utf8_lossy(&output.stderr));
+                if !self.suppress_output {
+                    // Forward stderr to parent process
+                    eprint!("{}", String::from_utf8_lossy(&output.stderr));
+                }
                 debug!("SSH stderr: {}", String::from_utf8_lossy(&output.stderr));
             }
 

--- a/crates/kit/src/libvirt/start.rs
+++ b/crates/kit/src/libvirt/start.rs
@@ -45,6 +45,7 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtStartOpts)
                 timeout: 30,
                 log_level: "ERROR".to_string(),
                 extra_options: vec![],
+                suppress_output: false,
             };
             return crate::libvirt::ssh::run(global_opts, ssh_opts);
         }
@@ -81,6 +82,7 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, opts: LibvirtStartOpts)
             timeout: 30,
             log_level: "ERROR".to_string(),
             extra_options: vec![],
+            suppress_output: false,
         };
         crate::libvirt::ssh::run(global_opts, ssh_opts)
     } else {

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -95,6 +95,10 @@ Run a bootable container as a persistent VM
 
     Automatically SSH into the VM after creation
 
+**--ssh-wait**
+
+    Wait for SSH to become available and verify connectivity (for testing)
+
 **--bind-storage-ro**
 
     Mount host container storage (RO) at /run/host-container-storage


### PR DESCRIPTION
Add a new `--ssh-wait` flag to `bcvk libvirt run` that waits for SSH to become available without entering an interactive shell. This is designed for use in test suites that need to verify a VM is fully booted and SSH-ready before proceeding with additional operations.

The `--ssh` flag behavior now also starts using this code, as does some of the integration tests.

Assisted-by: Claude Code (Sonnet 4.5)