### PR TITLE
cache_metadata: Fix parent directory handling for bare filenames

### DIFF
--- a/crates/kit/src/cache_metadata.rs
+++ b/crates/kit/src/cache_metadata.rs
@@ -123,9 +123,11 @@ impl DiskImageMetadata {
         }
 
         // Get the parent directory and file name
+        // Use current directory if parent is empty (for bare filenames like "disk.img")
         let parent = path
             .parent()
-            .ok_or_else(|| color_eyre::eyre::eyre!("Path has no parent directory"))?;
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
         let file_name = path
             .file_name()
             .ok_or_else(|| color_eyre::eyre::eyre!("Path has no file name"))?;
@@ -191,9 +193,11 @@ pub fn check_cached_disk(
     let expected_hash = expected_meta.compute_cache_hash();
 
     // Read the cache hash from the disk image
+    // Use current directory if parent is empty (for bare filenames like "disk.img")
     let parent = path
         .parent()
-        .ok_or_else(|| color_eyre::eyre::eyre!("Path has no parent directory"))?;
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
     let file_name = path
         .file_name()
         .ok_or_else(|| color_eyre::eyre::eyre!("Path has no file name"))?;


### PR DESCRIPTION
When a bare filename like "disk.img" is passed to bcvk to-disk, path.parent() returns Some("") (empty string) instead of None. This caused Dir::open_ambient_dir() to fail with "No such file or directory" when trying to open an empty path.

The fix filters out empty parent paths and defaults to "." (current directory) for bare filenames, while preserving existing behavior for relative and absolute paths.

Fixes both check_cached_disk() and read_image_digest_from_path().

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude Code (Sonnet 4.5)