### PR TITLE
to-disk: Include source imgref in cache hash to prevent incorrect reuse

### DIFF
--- a/crates/kit/src/libvirt/base_disks.rs
+++ b/crates/kit/src/libvirt/base_disks.rs
@@ -19,7 +19,7 @@ pub fn find_or_create_base_disk(
     install_options: &InstallOptions,
     connect_uri: Option<&str>,
 ) -> Result<Utf8PathBuf> {
-    let metadata = DiskImageMetadata::from(install_options, image_digest);
+    let metadata = DiskImageMetadata::from(install_options, image_digest, source_image);
     let cache_hash = metadata.compute_cache_hash();
 
     // Extract short hash for filename (first 16 chars after "sha256:")
@@ -43,6 +43,7 @@ pub fn find_or_create_base_disk(
         if crate::cache_metadata::check_cached_disk(
             base_disk_path.as_std_path(),
             image_digest,
+            source_image,
             install_options,
         )?
         .is_ok()
@@ -130,6 +131,7 @@ fn create_base_disk(
     let metadata_valid = crate::cache_metadata::check_cached_disk(
         temp_disk_path.as_std_path(),
         image_digest,
+        source_image,
         install_options,
     )
     .context("Querying cached disk")?;

--- a/docs/src/man/bcvk-to-disk.md
+++ b/docs/src/man/bcvk-to-disk.md
@@ -111,6 +111,10 @@ The installation process:
 
     Add metadata to the container in key=value form
 
+**--dry-run**
+
+    Check if the disk would be regenerated without actually creating it
+
 <!-- END GENERATED OPTIONS -->
 
 # ARGUMENTS


### PR DESCRIPTION
Different image references (imgrefs) pointing to the same digest should not share cached disk images, because the source imgref determines the upgrade source for the installed system.

Add the `source_imgref` field to the cache metadata structures and include it in the cache hash computation.

Additionally, add a `--dry-run` flag to `to-disk` that prints whether the disk would be regenerated (`would-regenerate`) or reused (`would-reuse`) without actually creating it. This is useful for testing and scripting.

Closes: https://github.com/bootc-dev/bcvk/issues/138

Assisted-by: Claude Code (Sonnet 4.5)