### PR TITLE
libvirt-run: Add --update-from-host

### DIFF
--- a/crates/kit/src/cache_metadata.rs
+++ b/crates/kit/src/cache_metadata.rs
@@ -34,10 +34,16 @@ struct CacheInputs {
     /// This is crucial because it determines the upgrade source for the installed system
     source_imgref: String,
 
+    /// Target transport
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_transport: Option<String>,
+
     /// Filesystem type used for installation (e.g., "ext4", "xfs", "btrfs")
+    #[serde(skip_serializing_if = "Option::is_none")]
     filesystem: Option<String>,
 
     /// Root filesystem size if specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     root_size: Option<String>,
 
     /// Whether to use composefs-native storage
@@ -59,6 +65,9 @@ pub struct DiskImageMetadata {
     /// Source image reference (e.g., "quay.io/centos-bootc/centos-bootc:stream9")
     /// This is crucial because it determines the upgrade source for the installed system
     pub source_imgref: String,
+
+    /// Target transport
+    pub target_transport: Option<String>,
 
     /// Filesystem type used for installation (e.g., "ext4", "xfs", "btrfs")
     pub filesystem: Option<String>,
@@ -82,6 +91,7 @@ impl DiskImageMetadata {
         let inputs = CacheInputs {
             image_digest: self.digest.clone(),
             source_imgref: self.source_imgref.clone(),
+            target_transport: self.target_transport.clone(),
             filesystem: self.filesystem.clone(),
             root_size: self.root_size.clone(),
             composefs_backend: self.composefs_backend,
@@ -169,6 +179,7 @@ impl DiskImageMetadata {
             version: 1,
             digest: image_digest.to_owned(),
             source_imgref: source_imgref.to_owned(),
+            target_transport: options.target_transport.clone(),
             filesystem: options.filesystem.clone(),
             root_size: options.root_size.clone(),
             kernel_args: options.karg.clone(),
@@ -326,6 +337,7 @@ mod tests {
         let inputs = CacheInputs {
             image_digest: "sha256:abc123".to_string(),
             source_imgref: "quay.io/test/image:v1".to_string(),
+            target_transport: None,
             filesystem: Some("ext4".to_string()),
             root_size: Some("20G".to_string()),
             kernel_args: vec!["console=ttyS0".to_string()],

--- a/crates/kit/src/install_options.rs
+++ b/crates/kit/src/install_options.rs
@@ -29,6 +29,10 @@ pub struct InstallOptions {
     )]
     pub storage_path: Option<Utf8PathBuf>,
 
+    /// The transport; e.g. oci, oci-archive, containers-storage.  Defaults to `registry`
+    #[clap(long)]
+    pub target_transport: Option<String>,
+
     #[clap(long)]
     /// Set a kernel argument
     pub karg: Vec<String>,
@@ -55,6 +59,11 @@ impl InstallOptions {
 
         for k in self.karg.iter() {
             args.push(format!("--karg={k}"));
+        }
+
+        if let Some(ref t) = self.target_transport {
+            args.push("--target-transport".to_string());
+            args.push(t.clone());
         }
 
         if self.composefs_backend {

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -57,6 +57,10 @@ Run a bootable container as a persistent VM
 
     Path to host container storage (auto-detected if not specified)
 
+**--target-transport**=*TARGET_TRANSPORT*
+
+    The transport; e.g. oci, oci-archive, containers-storage.  Defaults to `registry`
+
 **--karg**=*KARG*
 
     Set a kernel argument
@@ -102,6 +106,10 @@ Run a bootable container as a persistent VM
 **--bind-storage-ro**
 
     Mount host container storage (RO) at /run/host-container-storage
+
+**--update-from-host**
+
+    Implies --bind-storage-ro, but also configure to update from the host container storage by default
 
 **--firmware**=*FIRMWARE*
 

--- a/docs/src/man/bcvk-libvirt-upload.md
+++ b/docs/src/man/bcvk-libvirt-upload.md
@@ -45,6 +45,10 @@ Upload bootc disk images to libvirt with metadata annotations
 
     Path to host container storage (auto-detected if not specified)
 
+**--target-transport**=*TARGET_TRANSPORT*
+
+    The transport; e.g. oci, oci-archive, containers-storage.  Defaults to `registry`
+
 **--karg**=*KARG*
 
     Set a kernel argument

--- a/docs/src/man/bcvk-to-disk.md
+++ b/docs/src/man/bcvk-to-disk.md
@@ -47,6 +47,10 @@ The installation process:
 
     Path to host container storage (auto-detected if not specified)
 
+**--target-transport**=*TARGET_TRANSPORT*
+
+    The transport; e.g. oci, oci-archive, containers-storage.  Defaults to `registry`
+
 **--karg**=*KARG*
 
     Set a kernel argument


### PR DESCRIPTION
This streamlines the UX of upgrading from a local build; it's part of the idea of https://github.com/bootc-dev/bcvk/pull/86 but this is a lot smaller than that.