### PR TITLE
ephemeral: Fix execute unit

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -932,7 +932,8 @@ WantedBy=sysinit.target
             let mut service_content = format!(
                 r#"[Unit]
 Description=Execute Script Service
-Requires=dev-virtio\\x2dports-execute.device
+Requires=dev-virtio\x2dports-execute.device
+After=dev-virtio\x2dports-execute.device
 
 [Service]
 Type=oneshot
@@ -948,7 +949,8 @@ StandardError=inherit
             let service_finish = r#"[Unit]
 Description=Execute Script Service Completion
 After=bootc-execute.service
-Requires=dev-virtio\\x2dports-executestatus.device
+Requires=dev-virtio\x2dports-executestatus.device
+After=dev-virtio\x2dports-executestatus.device
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This one was subtle...at some point we moved over to Rust raw strings `r#` where we no longer needed `\\`. The next bug here is we were missing `After=`.

The semantics of a plain `Requires=` without `After=` are very weak and systemd basically skipped over the missing device.

Closes: https://github.com/bootc-dev/bcvk/issues/139