### PR TITLE
Add a check for required binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "vsock",
+ "which",
  "xshell",
  "yaml-rust2",
 ]
@@ -715,6 +716,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -2997,6 +3004,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,6 +3379,12 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "winx"

--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -49,6 +49,7 @@ strum = { version = "0.26", features = ["derive"] }
 quick-xml = "0.36"
 oci-spec = "0.8.2"
 sha2 = "0.10"
+which = "7.0"
 
 [dev-dependencies]
 similar-asserts = "1.5"

--- a/crates/kit/scripts/entrypoint.sh
+++ b/crates/kit/scripts/entrypoint.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 SELFEXE=/run/selfexe
 
+# Check for required binaries early
+if ! command -v bwrap &>/dev/null; then
+    echo "Error: bwrap (bubblewrap) is currently required in the target container image" >&2
+    exit 1
+fi
+
 # Shell script library
 init_tmproot() {
     if test -d /run/tmproot; then return 0; fi


### PR DESCRIPTION
- We require bwrap in the target container currently, make that clear. That needs to be done in the entrypoint shell script.
- Once we're past that we're in Rust, so add infrastructure to verify that we have systemctl also; this list will be extended in the future