### PR TITLE
ephemeral: Fix `run-ssh` error handling

### DIFF
--- a/crates/integration-tests/fixtures/Dockerfile.no-kernel
+++ b/crates/integration-tests/fixtures/Dockerfile.no-kernel
@@ -1,0 +1,10 @@
+# Test fixture: Bootc image with kernel removed
+# This simulates a broken/malformed bootc image that will fail during ephemeral VM startup
+# Used to test error handling and cleanup in ephemeral run-ssh command
+
+ARG BASE_IMAGE=quay.io/centos-bootc/centos-bootc:stream10
+
+FROM ${BASE_IMAGE}
+
+# Remove kernel and modules to simulate a broken bootc image
+RUN rm -rf /usr/lib/modules

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -777,7 +777,10 @@ pub(crate) async fn run_impl(opts: RunEphemeralOpts) -> Result<()> {
     let mut vmlinuz_path: Option<Utf8PathBuf> = None;
     let mut initramfs_path: Option<Utf8PathBuf> = None;
 
-    for entry in fs::read_dir(modules_dir)? {
+    let entries = fs::read_dir(modules_dir)
+        .with_context(|| format!("Failed to read kernel modules directory at {}. This container image may not be a valid bootc image.", modules_dir))?;
+
+    for entry in entries {
         let entry = entry?;
         let path = Utf8PathBuf::from_path_buf(entry.path())
             .map_err(|p| eyre!("Path is not valid UTF-8: {}", p.display()))?;


### PR DESCRIPTION
If we fail to launch, because we used `--rm` the container would exit and we couldn't get its logs.

Change to removing the container image via a drop handler, so if the system fails to launch (e.g. it's missing a kernel or bwrap) we can get the logs from that.