### PR TITLE
libvirt: Add --replace to run, make rm -f stop by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "libtest-mimic",
  "linkme",
  "paste",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serde_json",

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -34,6 +34,7 @@ camino = "1.1.12"
 regex = "1"
 linkme = "0.3.30"
 paste = "1.0"
+rand = { workspace = true }
 
 [lints]
 workspace = true

--- a/docs/src/man/bcvk-libvirt-rm.md
+++ b/docs/src/man/bcvk-libvirt-rm.md
@@ -21,11 +21,11 @@ Remove a libvirt domain and its resources
 
 **-f**, **--force**
 
-    Force removal without confirmation
+    Force removal without confirmation (also stops running VMs)
 
 **--stop**
 
-    Remove domain even if it's running
+    Stop domain if it's running (implied by --force)
 
 <!-- END GENERATED OPTIONS -->
 

--- a/docs/src/man/bcvk-libvirt-run.md
+++ b/docs/src/man/bcvk-libvirt-run.md
@@ -23,6 +23,10 @@ Run a bootable container as a persistent VM
 
     Name for the VM (auto-generated if not specified)
 
+**-R**, **--replace**
+
+    Replace existing VM with same name (stop and remove if exists)
+
 **--itype**=*ITYPE*
 
     Instance type (e.g., u1.nano, u1.small, u1.medium). Overrides cpus/memory if specified.


### PR DESCRIPTION
When I say `--force` I mean it; needing to stop the VM manually was just annoying.

Add run --replace/-R to forcibly destroy and recreate a VM with the same name, matching podman run --replace behavior. This is useful for quick iteration during development and testing.

Assisted-by: Claude Code (Sonnet 4.5)