### PR TITLE
ephemeral: Add an option to override the entrypoint

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -240,6 +240,11 @@ pub struct RunEphemeralOpts {
     #[clap(flatten)]
     pub podman: CommonPodmanOptions,
 
+    /// Do not run the default entrypoint directly, but
+    /// instead invoke the provided command (e.g. `bash`).
+    #[clap(long)]
+    pub debug_entrypoint: Option<String>,
+
     #[clap(
         long = "bind",
         value_name = "HOST_PATH[:NAME]",
@@ -520,7 +525,8 @@ fn prepare_run_command_with_temp(
         cmd.args(["-e", &format!("BOOTC_DISK_FILES={}", disk_specs)]);
     }
 
-    cmd.args([&opts.image, ENTRYPOINT]);
+    let entrypoint = opts.debug_entrypoint.as_deref().unwrap_or(ENTRYPOINT);
+    cmd.args([&opts.image, entrypoint]);
 
     Ok((cmd, td))
 }

--- a/crates/kit/src/to_disk.rs
+++ b/crates/kit/src/to_disk.rs
@@ -453,6 +453,7 @@ pub fn run(opts: ToDiskOpts) -> Result<()> {
             opts.additional.format.as_str()
         )], // Attach target disk
         kernel_args: Default::default(),
+        debug_entrypoint: None,
     };
 
     // Phase 5: SSH-based VM configuration and execution

--- a/docs/src/man/bcvk-ephemeral-run-ssh.md
+++ b/docs/src/man/bcvk-ephemeral-run-ssh.md
@@ -89,6 +89,10 @@ Run ephemeral VM and SSH into it
 
     Set environment variables in the container (key=value)
 
+**--debug-entrypoint**=*DEBUG_ENTRYPOINT*
+
+    Do not run the default entrypoint directly, but instead invoke the provided command (e.g. `bash`)
+
 **--bind**=*HOST_PATH[:NAME]*
 
     Bind mount host directory (RW) at /run/virtiofs-mnt-<name>

--- a/docs/src/man/bcvk-ephemeral-run.md
+++ b/docs/src/man/bcvk-ephemeral-run.md
@@ -115,6 +115,10 @@ This design allows bcvk to provide VM-like isolation and boot behavior while lev
 
     Set environment variables in the container (key=value)
 
+**--debug-entrypoint**=*DEBUG_ENTRYPOINT*
+
+    Do not run the default entrypoint directly, but instead invoke the provided command (e.g. `bash`)
+
 **--bind**=*HOST_PATH[:NAME]*
 
     Bind mount host directory (RW) at /run/virtiofs-mnt-<name>


### PR DESCRIPTION
The goal is to make it easier to debug entrypoint failures as one can do e.g.

```
$ bcvk ephemeral run -ti --debug-entrypoint bash -K --name mytestvm2 quay.io/fedora/fedora-bootc:42
```

(And also e.g. interactively inspect the state of the container before
 bwrap and qemu is launched etc.)