### PR TITLE
ephemeral: Avoid double mounting

### DIFF
--- a/crates/kit/scripts/entrypoint.sh
+++ b/crates/kit/scripts/entrypoint.sh
@@ -11,13 +11,11 @@ fi
 
 # Shell script library
 init_tmproot() {
-    if test -d /run/tmproot; then return 0; fi
-    mkdir /run/tmproot
+    if test -d /run/inner-shared; then return 0; fi
+    # Should have been created by podman when initializing
+    # the bind mount
     cd /run/tmproot
 
-    # Bind mount host /usr to our hybrid root
-    mkdir usr
-    mount --bind /run/hostusr usr
     # Create essential symlinks
     ln -sf usr/bin bin
     ln -sf usr/lib lib

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -454,7 +454,11 @@ fn prepare_run_command_with_temp(
     cmd.args(vhost_dev);
     cmd.args([
         "-v",
-        "/usr:/run/hostusr:ro", // Bind mount host /usr as read-only
+        // The core way things work here is we run the host as a nested container
+        // inside an outer container. The rest of /run/tmproot will be populated
+        // in the entrypoint script, but we just grab the host's `/usr`.
+        // (We don't want all of `/` as that would scope in a lot more)
+        "/usr:/run/tmproot/usr:ro",
         "-v",
         &format!("{}:{}", entrypoint_path, ENTRYPOINT),
         "-v",


### PR DESCRIPTION
This may fix a failure Robert was seeing with a submount in `/usr`. But in general this is just cleaner anyways to avoid a double mount.