### PR TITLE
build-sys: Try testing alma 10.0 instead

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,7 @@
 PRIMARY_IMAGE := "quay.io/centos-bootc/centos-bootc:stream10"
-ALL_BASE_IMAGES := "quay.io/fedora/fedora-bootc:42 quay.io/centos-bootc/centos-bootc:stream9 quay.io/centos-bootc/centos-bootc:stream10 quay.io/almalinuxorg/almalinux-bootc:9.6"
+# TODO: Readd quay.io/almalinuxorg/almalinux-bootc:9.6 here after debugging
+# <https://github.com/bootc-dev/bcvk/issues/153>
+ALL_BASE_IMAGES := "quay.io/fedora/fedora-bootc:42 quay.io/centos-bootc/centos-bootc:stream9 quay.io/centos-bootc/centos-bootc:stream10 quay.io/almalinuxorg/almalinux-bootc:10.0"
 
 # Build the native binary
 build:


### PR DESCRIPTION
We're consistently hitting timeouts in CI, I haven't tried to debug it yet. Let's see if 10.0 is better.