### PR TITLE
virtiofs: Set SELinux context on readonly mounts

### DIFF
--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -882,8 +882,11 @@ fn process_bind_mounts(
 
         // Generate SMBIOS credential for mount unit (without dropin)
         let unit_name = crate::credentials::guest_path_to_unit_name(&bind_mount.guest_path);
-        let mount_unit_content =
-            crate::credentials::generate_mount_unit(&tag, &bind_mount.guest_path, readonly);
+        let mount_unit_content = crate::credentials::generate_virtiofs_mount_unit(
+            &tag,
+            &bind_mount.guest_path,
+            readonly,
+        );
         let encoded_mount = data_encoding::BASE64.encode(mount_unit_content.as_bytes());
         let mount_cred =
             format!("io.systemd.credential.binary:systemd.extra-unit.{unit_name}={encoded_mount}");
@@ -1211,7 +1214,7 @@ fn create_libvirt_domain_from_disk(
         let guest_mount_path = "/run/host-container-storage";
         let unit_name = crate::credentials::guest_path_to_unit_name(guest_mount_path);
         let mount_unit_content =
-            crate::credentials::generate_mount_unit("hoststorage", guest_mount_path, true);
+            crate::credentials::generate_virtiofs_mount_unit("hoststorage", guest_mount_path, true);
         let encoded_mount = data_encoding::BASE64.encode(mount_unit_content.as_bytes());
         let mount_cred =
             format!("io.systemd.credential.binary:systemd.extra-unit.{unit_name}={encoded_mount}");

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -915,7 +915,7 @@ pub(crate) async fn run_impl(opts: RunEphemeralOpts) -> Result<()> {
             let mount_point = format!("/run/virtiofs-mnt-{}", mount_name_str);
             let unit_name = crate::credentials::guest_path_to_unit_name(&mount_point);
             let mount_unit_content =
-                crate::credentials::generate_mount_unit(&tag, &mount_point, is_readonly);
+                crate::credentials::generate_virtiofs_mount_unit(&tag, &mount_point, is_readonly);
             let encoded_mount = data_encoding::BASE64.encode(mount_unit_content.as_bytes());
 
             // Create SMBIOS credential for the mount unit


### PR DESCRIPTION
Apply system_u:object_r:usr_t:s0 context to readonly virtiofs mounts to avoid SELinux denials when accessing them as container storage. This allows readonly bind mounts to work correctly with podman.

The function was renamed from generate_mount_unit to generate_virtiofs_mount_unit for clarity.

Assisted-by: Claude Code (Sonnet 4.5)