### PR TITLE
virtiofsd_paths: Extends virtiofsd binary locations

### DIFF
--- a/crates/kit/src/qemu.rs
+++ b/crates/kit/src/qemu.rs
@@ -884,6 +884,7 @@ pub async fn spawn_virtiofsd_async(config: &VirtiofsConfig) -> Result<tokio::pro
         "/usr/libexec/virtiofsd",
         "/usr/bin/virtiofsd",
         "/usr/local/bin/virtiofsd",
+        "/usr/lib/virtiofsd",
     ];
 
     let virtiofsd_binary = virtiofsd_paths


### PR DESCRIPTION
This commit extends the list of virtiofsd binary locations. This change enables running a bootc container as an ephemeral VM on Arch Linux, as the Arch package installs the virtiofsd binary in /usr/lib/virtiofsd.

bcvk is crashing because it cannot locate the virtiofsd binary.

```                                                                                                                                                                                            
$ ./bcvk-x86_64-unknown-linux-gnu ephemeral run --rm -K --name mytestvm quay.io/fedora/fedora-bootc:42
Error:
   0: virtiofsd binary not found. Searched paths: /usr/libexec/virtiofsd, /usr/bin/virtiofsd, /usr/local/bin/virtiofsd. Please install virtiofsd.
   
Location:
   crates/kit/src/qemu.rs:893
   
Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```
   
The virtiofsd package files are listed here. On Arch Linux, the virtiofsd binary is found at /usr/lib/virtiofsd.

```
$ pacman -Ql virtiofsd
virtiofsd /usr/ 
virtiofsd /usr/lib/
virtiofsd /usr/lib/virtiofsd
virtiofsd /usr/share/
virtiofsd /usr/share/doc/
virtiofsd /usr/share/doc/virtiofsd/
virtiofsd /usr/share/doc/virtiofsd/README.md
virtiofsd /usr/share/doc/virtiofsd/migration.md
virtiofsd /usr/share/doc/virtiofsd/xattr-mapping.md
virtiofsd /usr/share/licenses/
virtiofsd /usr/share/licenses/virtiofsd/
virtiofsd /usr/share/licenses/virtiofsd/LICENSE-APACHE
virtiofsd /usr/share/licenses/virtiofsd/LICENSE-BSD-3-Clause
virtiofsd /usr/share/qemu/
virtiofsd /usr/share/qemu/vhost-user/
virtiofsd /usr/share/qemu/vhost-user/50-virtiofsd.json
```

I implemented a temporary workaround by creating a symlink to /usr/local/bin/virtiofsd.

```
$ sudo ln -s /usr/lib/virtiofsd /usr/local/bin/virtiofsd
$ ./bcvk-x86_64-unknown-linux-gnu ephemeral run -d --rm -K --name mytestvm quay.io/fedora/fedora-bootc:42
4250423d0f016ed3c84c3325232d20b7640c95afd814bfe2acdfc2bcdbd37f62
$ ./bcvk-x86_64-unknown-linux-gnu ephemeral ssh mytestvm
[root@fedora ~]# 
```