### PR TITLE
Fix DNS resolution in ephemeral guests

### DIFF
--- a/crates/kit/scripts/entrypoint.sh
+++ b/crates/kit/scripts/entrypoint.sh
@@ -25,6 +25,12 @@ init_tmproot() {
     # Ensure we have /etc/passwd as ssh-keygen wants it for bad reasons
     systemd-sysusers --root $(pwd) &>/dev/null
 
+    # Copy DNS configuration from container's /etc/resolv.conf (configured by podman --dns)
+    # into the bwrap namespace so QEMU's slirp can use it for DNS resolution
+    if [ -f /etc/resolv.conf ]; then
+        cp /etc/resolv.conf /run/tmproot/etc/resolv.conf
+    fi
+
     # Shared directory between containers
     mkdir /run/inner-shared
 }

--- a/crates/kit/src/qemu.rs
+++ b/crates/kit/src/qemu.rs
@@ -523,22 +523,20 @@ fn spawn(
     // Configure network (only User mode supported now)
     match &config.network_mode {
         NetworkMode::User { hostfwd } => {
-            if hostfwd.is_empty() {
-                cmd.args([
-                    "-netdev",
-                    "user,id=net0",
-                    "-device",
-                    "virtio-net-pci,netdev=net0",
-                ]);
-            } else {
-                let hostfwd_arg = format!("user,id=net0,hostfwd={}", hostfwd.join(",hostfwd="));
-                cmd.args([
-                    "-netdev",
-                    &hostfwd_arg,
-                    "-device",
-                    "virtio-net-pci,netdev=net0",
-                ]);
+            let mut netdev_parts = vec!["user".to_string(), "id=net0".to_string()];
+
+            // Add port forwarding rules
+            for fwd in hostfwd {
+                netdev_parts.push(format!("hostfwd={}", fwd));
             }
+
+            let netdev_arg = netdev_parts.join(",");
+            cmd.args([
+                "-netdev",
+                &netdev_arg,
+                "-device",
+                "virtio-net-pci,netdev=net0",
+            ]);
         }
     }
 

--- a/crates/kit/src/to_disk.rs
+++ b/crates/kit/src/to_disk.rs
@@ -430,6 +430,7 @@ pub fn run(opts: ToDiskOpts) -> Result<()> {
     // - Attach target disk via virtio-blk
     // - Disable networking (using local storage only)
     let ephemeral_opts = RunEphemeralOpts {
+        host_dns_servers: None,
         image: opts.get_installer_image().to_string(),
         common: common_opts,
         podman: crate::run_ephemeral::CommonPodmanOptions {


### PR DESCRIPTION
Configure QEMU user-mode networking to use host DNS servers from /etc/resolv.conf instead of the default 10.0.2.3, which doesn't work when QEMU runs inside containers.