### PR TITLE
ephemeral: Replace systemd.volatile=overlay with fine-grained mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "color-eyre",
  "comfy-table",
  "const_format",
+ "cpio",
  "data-encoding",
  "dirs",
  "fn-error-context",
@@ -515,6 +516,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpio"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938e716cb1ade5d6c8f959c13a7248b889c07491fc7e41167c3afe20f8f0de1e"
 
 [[package]]
 name = "cpufeatures"

--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -50,6 +50,7 @@ quick-xml = "0.36"
 oci-spec = "0.8.2"
 sha2 = "0.10"
 which = "7.0"
+cpio = "0.4"
 
 [dev-dependencies]
 similar-asserts = "1.5"

--- a/crates/kit/src/cpio.rs
+++ b/crates/kit/src/cpio.rs
@@ -1,0 +1,166 @@
+//! CPIO archive creation for initramfs appending.
+//!
+//! The Linux kernel supports concatenating multiple CPIO archives,
+//! so we can simply append our files to an existing initramfs.
+
+use std::io::{self, Write};
+
+use cpio::newc::Builder as NewcBuilder;
+use cpio::newc::ModeFileType;
+
+fn write_directory(writer: &mut impl Write, path: &str) -> io::Result<()> {
+    let builder = NewcBuilder::new(path)
+        .mode(0o755)
+        .set_mode_file_type(ModeFileType::Directory);
+    builder.write(writer, 0).finish()?;
+    Ok(())
+}
+
+fn write_file(writer: &mut impl Write, path: &str, content: &[u8]) -> io::Result<()> {
+    let builder = NewcBuilder::new(path)
+        .mode(0o644)
+        .set_mode_file_type(ModeFileType::Regular);
+    let mut cpio_writer = builder.write(writer, content.len() as u32);
+    cpio_writer.write_all(content)?;
+    cpio_writer.finish()?;
+    Ok(())
+}
+
+/// CPIO entry: either a directory or a file with content.
+enum Entry {
+    Dir(&'static str),
+    File(&'static str, &'static [u8]),
+}
+
+/// Create a CPIO archive with bcvk initramfs units for ephemeral VM setup.
+pub fn create_initramfs_units_cpio() -> io::Result<Vec<u8>> {
+    use Entry::*;
+
+    const UNIT_DIR: &str = "usr/lib/systemd/system";
+    const DROPIN_DIR: &str = "usr/lib/systemd/system/initrd-fs.target.d";
+
+    let entries: &[Entry] = &[
+        // Directory hierarchy
+        Dir("usr"),
+        Dir("usr/lib"),
+        Dir("usr/lib/systemd"),
+        Dir(UNIT_DIR),
+        Dir(DROPIN_DIR),
+        // Service units
+        File(
+            "usr/lib/systemd/system/bcvk-etc-overlay.service",
+            include_bytes!("units/bcvk-etc-overlay.service"),
+        ),
+        File(
+            "usr/lib/systemd/system/bcvk-var-ephemeral.service",
+            include_bytes!("units/bcvk-var-ephemeral.service"),
+        ),
+        File(
+            "usr/lib/systemd/system/bcvk-copy-units.service",
+            include_bytes!("units/bcvk-copy-units.service"),
+        ),
+        File(
+            "usr/lib/systemd/system/bcvk-journal-stream.service",
+            include_bytes!("units/bcvk-journal-stream.service"),
+        ),
+        // Drop-in configs to pull units into initrd-fs.target
+        File(
+            "usr/lib/systemd/system/initrd-fs.target.d/bcvk-etc-overlay.conf",
+            b"[Unit]\nWants=bcvk-etc-overlay.service\n",
+        ),
+        File(
+            "usr/lib/systemd/system/initrd-fs.target.d/bcvk-var-ephemeral.conf",
+            b"[Unit]\nWants=bcvk-var-ephemeral.service\n",
+        ),
+        File(
+            "usr/lib/systemd/system/initrd-fs.target.d/bcvk-copy-units.conf",
+            b"[Unit]\nWants=bcvk-copy-units.service\n",
+        ),
+    ];
+
+    let mut buf = Vec::new();
+    for entry in entries {
+        match entry {
+            Dir(path) => write_directory(&mut buf, path)?,
+            File(path, content) => write_file(&mut buf, path, content)?,
+        }
+    }
+
+    cpio::newc::trailer(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Read};
+
+    #[test]
+    fn test_cpio_archive_structure_and_contents() {
+        let cpio_data = create_initramfs_units_cpio().unwrap();
+        let mut cursor = Cursor::new(cpio_data);
+
+        let mut entries = Vec::new();
+        let mut etc_overlay_content = None;
+
+        loop {
+            let mut reader = cpio::NewcReader::new(cursor).expect("failed to read CPIO entry");
+            if reader.entry().is_trailer() {
+                break;
+            }
+
+            let name = reader.entry().name().to_string();
+            let size = reader.entry().file_size() as usize;
+            let mode = reader.entry().mode();
+
+            // Read file content for verification
+            if name == "usr/lib/systemd/system/bcvk-etc-overlay.service" {
+                let mut content = vec![0u8; size];
+                reader
+                    .read_exact(&mut content)
+                    .expect("failed to read file content");
+                etc_overlay_content = Some(String::from_utf8(content).expect("invalid UTF-8"));
+            }
+
+            entries.push((name, size, mode));
+            cursor = reader.finish().expect("failed to finish entry");
+        }
+
+        let names: Vec<_> = entries.iter().map(|(n, _, _)| n.as_str()).collect();
+
+        // Verify directories
+        assert!(names.contains(&"usr"));
+        assert!(names.contains(&"usr/lib"));
+        assert!(names.contains(&"usr/lib/systemd"));
+        assert!(names.contains(&"usr/lib/systemd/system"));
+        assert!(names.contains(&"usr/lib/systemd/system/initrd-fs.target.d"));
+
+        // Verify service files
+        assert!(names.contains(&"usr/lib/systemd/system/bcvk-etc-overlay.service"));
+        assert!(names.contains(&"usr/lib/systemd/system/bcvk-var-ephemeral.service"));
+        assert!(names.contains(&"usr/lib/systemd/system/bcvk-copy-units.service"));
+        assert!(names.contains(&"usr/lib/systemd/system/bcvk-journal-stream.service"));
+
+        // Verify drop-in configs
+        assert!(names.contains(&"usr/lib/systemd/system/initrd-fs.target.d/bcvk-etc-overlay.conf"));
+        assert!(
+            names.contains(&"usr/lib/systemd/system/initrd-fs.target.d/bcvk-var-ephemeral.conf")
+        );
+        assert!(names.contains(&"usr/lib/systemd/system/initrd-fs.target.d/bcvk-copy-units.conf"));
+
+        // Verify file modes
+        for (name, _size, mode) in &entries {
+            let file_type = *mode & 0o170000;
+            if name.ends_with(".service") || name.ends_with(".conf") {
+                assert_eq!(file_type, 0o100000, "{} should be regular file", name);
+            } else {
+                assert_eq!(file_type, 0o040000, "{} should be directory", name);
+            }
+        }
+
+        // Verify file content is valid systemd unit
+        let content = etc_overlay_content.expect("bcvk-etc-overlay.service not found");
+        assert!(content.contains("[Unit]"));
+        assert!(content.contains("[Service]"));
+        assert!(content.contains("overlay"));
+    }
+}

--- a/crates/kit/src/lib.rs
+++ b/crates/kit/src/lib.rs
@@ -1,4 +1,5 @@
 //! bcvk library - exposes internal modules for testing
 
+pub mod cpio;
 pub mod qemu_img;
 pub mod xml_utils;

--- a/crates/kit/src/main.rs
+++ b/crates/kit/src/main.rs
@@ -10,6 +10,7 @@ mod cache_metadata;
 mod cli_json;
 mod common_opts;
 mod container_entrypoint;
+mod cpio;
 mod credentials;
 mod domain_list;
 mod ephemeral;

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -944,28 +944,60 @@ pub(crate) async fn run_impl(opts: RunEphemeralOpts) -> Result<()> {
     } else {
         let vmlinuz_path = vmlinuz_path
             .ok_or_else(|| eyre!("No kernel found in /run/source-image/usr/lib/modules"))?;
-        let initramfs_path = initramfs_path
+        let source_initramfs_path = initramfs_path
             .ok_or_else(|| eyre!("No initramfs found in /run/source-image/usr/lib/modules"))?;
 
         fs::File::create(&kernel_mount)?;
-        fs::File::create(&initramfs_mount)?;
 
-        // Bind mount kernel and initramfs
+        // Bind mount kernel (read-only is fine)
         Command::new("mount")
             .args(["--bind", "-o", "ro", vmlinuz_path.as_str(), &kernel_mount])
             .run()
             .map_err(|e| eyre!("Failed to bind mount kernel: {e}"))?;
 
-        Command::new("mount")
-            .args([
-                "--bind",
-                "-o",
-                "ro",
-                initramfs_path.as_str(),
-                &initramfs_mount,
-            ])
-            .run()
-            .map_err(|e| eyre!("Failed to bind mount initramfs: {e}"))?;
+        // Copy initramfs so we can append to it
+        fs::copy(&source_initramfs_path, &initramfs_mount)
+            .map_err(|e| eyre!("Failed to copy initramfs: {e}"))?;
+    }
+
+    // Append bcvk units to initramfs
+    // This includes:
+    // - /etc overlay and /var ephemeral services (run in initramfs)
+    // - bcvk-copy-units.service (copies journal-stream to /sysroot/etc for systemd <256)
+    // - bcvk-journal-stream.service (embedded for systemd <256 compatibility)
+    //
+    // The Linux kernel's initramfs parser requires uncompressed CPIO archives to start
+    // at a 4-byte aligned offset. We add NUL padding before our CPIO data to ensure
+    // proper alignment. The kernel skips NUL bytes between archives.
+    {
+        use std::io::{Seek, SeekFrom, Write};
+        let cpio_data = crate::cpio::create_initramfs_units_cpio()
+            .map_err(|e| eyre!("Failed to create initramfs CPIO: {e}"))?;
+        let mut initramfs_file = fs::OpenOptions::new()
+            .append(true)
+            .open(&initramfs_mount)
+            .map_err(|e| eyre!("Failed to open initramfs for appending: {e}"))?;
+
+        // Get current file size to calculate alignment padding
+        let current_size: u64 = initramfs_file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| eyre!("Failed to get initramfs size: {e}"))?;
+        let aligned_size = current_size.next_multiple_of(4);
+        let padding_needed = aligned_size - current_size;
+        if padding_needed > 0 {
+            initramfs_file
+                .write_all(&vec![0u8; padding_needed as usize])
+                .map_err(|e| eyre!("Failed to write alignment padding: {e}"))?;
+        }
+
+        initramfs_file
+            .write_all(&cpio_data)
+            .map_err(|e| eyre!("Failed to append bcvk units to initramfs: {e}"))?;
+        debug!(
+            "Appended bcvk units to initramfs ({} bytes padding + {} bytes CPIO)",
+            padding_needed,
+            cpio_data.len()
+        );
     }
 
     // Process host mounts and prepare virtiofsd instances for each using async manager
@@ -1053,6 +1085,11 @@ pub(crate) async fn run_impl(opts: RunEphemeralOpts) -> Result<()> {
         );
     }
 
+    // Note: /etc overlay and /var ephemeral units are now embedded directly in the
+    // initramfs CPIO (see cpio.rs) rather than injected via SMBIOS credentials.
+    // This ensures they work on systemd <256 where credential import happens too
+    // late for generators to process.
+
     // Handle --execute: pipes will be created when adding to qemu_config later
     // No need to create files anymore as we're using pipes
 
@@ -1099,6 +1136,8 @@ WantedBy=sysinit.target
 Description=Execute Script Service
 Requires=dev-virtio\x2dports-execute.device
 After=dev-virtio\x2dports-execute.device
+# Ensure we only run after switch-root in the real root filesystem
+ConditionPathExists=!/etc/initrd-release
 
 [Service]
 Type=oneshot
@@ -1116,6 +1155,8 @@ Description=Execute Script Service Completion
 After=bootc-execute.service
 Requires=dev-virtio\x2dports-executestatus.device
 After=dev-virtio\x2dports-executestatus.device
+# Ensure we only run after switch-root in the real root filesystem
+ConditionPathExists=!/etc/initrd-release
 
 [Service]
 Type=oneshot
@@ -1137,12 +1178,14 @@ StandardOutput=file:/dev/virtio-ports/executestatus
             );
             mount_unit_smbios_creds.push(finish_cred);
 
-            // Create dropin for default.target to enable execute services
+            // Create dropin for multi-user.target to enable execute services
+            // Using multi-user.target instead of default.target ensures these only run
+            // after switch-root in the real root filesystem (not in initramfs)
             let execute_dropin =
                 "[Unit]\nWants=bootc-execute.service bootc-execute-finish.service\n";
             let encoded_dropin = data_encoding::BASE64.encode(execute_dropin.as_bytes());
             let dropin_cred = format!(
-                "io.systemd.credential.binary:systemd.unit-dropin.default.target~bcvk-execute={encoded_dropin}"
+                "io.systemd.credential.binary:systemd.unit-dropin.multi-user.target~bcvk-execute={encoded_dropin}"
             );
             mount_unit_smbios_creds.push(dropin_cred);
             debug!("Generated SMBIOS credentials for execute units");
@@ -1188,10 +1231,10 @@ StandardOutput=file:/dev/virtio-ports/executestatus
         // At the core we boot from the mounted container's root,
         "rootfstype=virtiofs",
         "root=rootfs",
-        // But read-only, with an overlayfs in the VM backed
-        // by tmpfs
+        // But read-only. We set up /etc overlay and /var copyup via
+        // systemd credentials rather than systemd.volatile=overlay
+        // to have more control over individual directories.
         "rootflags=ro",
-        "systemd.volatile=overlay",
         // This avoids having journald interact with the rootfs
         // at all, which lessens the I/O traffic for virtiofs
         "systemd.journald.storage=volatile",

--- a/crates/kit/src/units/bcvk-copy-units.service
+++ b/crates/kit/src/units/bcvk-copy-units.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Copy bcvk units for post-switch-root on systemd <256
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+Before=initrd-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# On systemd <256, SMBIOS credentials with systemd.extra-unit.* are not processed
+# natively. We work around this by embedding the units in the initramfs and copying
+# them to /run/systemd/system/ before switch-root. The /run tmpfs is preserved
+# across switch-root via MS_MOVE.
+#
+# Copy journal-stream unit and create dropin for sysinit.target
+ExecStart=/bin/sh -c 'mkdir -p /run/systemd/system/sysinit.target.wants && cp /usr/lib/systemd/system/bcvk-journal-stream.service /run/systemd/system/ && ln -s ../bcvk-journal-stream.service /run/systemd/system/sysinit.target.wants/'

--- a/crates/kit/src/units/bcvk-etc-overlay.service
+++ b/crates/kit/src/units/bcvk-etc-overlay.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Setup ephemeral /etc overlay
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+Before=initrd-fs.target
+# Must run after sysroot.mount and initrd-parse-etc.service which scans /sysroot/etc/fstab
+After=sysroot.mount initrd-parse-etc.service
+Requires=sysroot.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=30
+# Bind-mount /sysroot/etc to a separate location first, then use that as lowerdir.
+# Using /sysroot/etc as both lowerdir and mount destination can hang on older kernels.
+ExecStart=/usr/bin/mkdir -p /run/etc-lower /run/etc-upper /run/etc-work
+ExecStart=/usr/bin/mount --bind /sysroot/etc /run/etc-lower
+# Use index=off,metacopy=off to avoid extended attr operations on virtiofs
+ExecStart=/usr/bin/mount -t overlay overlay -o lowerdir=/run/etc-lower,upperdir=/run/etc-upper,workdir=/run/etc-work,index=off,metacopy=off /sysroot/etc

--- a/crates/kit/src/units/bcvk-journal-stream.service
+++ b/crates/kit/src/units/bcvk-journal-stream.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Stream systemd journal to host via virtio-serial
+DefaultDependencies=no
+After=systemd-journald.service dev-virtio\x2dports-org.bcvk.journal.device
+Requires=systemd-journald.service dev-virtio\x2dports-org.bcvk.journal.device
+# Only run after switch-root (not in initramfs)
+ConditionPathExists=!/etc/initrd-release
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/journalctl -f -o short-precise --no-pager
+StandardOutput=file:/dev/virtio-ports/org.bcvk.journal
+StandardError=file:/dev/virtio-ports/org.bcvk.journal
+Restart=always
+RestartSec=1s
+
+[Install]
+WantedBy=sysinit.target

--- a/crates/kit/src/units/bcvk-var-ephemeral.service
+++ b/crates/kit/src/units/bcvk-var-ephemeral.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Setup ephemeral /var from image content
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+Before=initrd-fs.target
+After=sysroot.mount initrd-parse-etc.service
+Requires=sysroot.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+TimeoutStartSec=60
+ExecStart=/usr/bin/mkdir -p /run/var-ephemeral
+ExecStart=/usr/bin/cp -a /sysroot/var/. /run/var-ephemeral/
+ExecStart=/usr/bin/mount --bind /run/var-ephemeral /sysroot/var


### PR DESCRIPTION
Instead of using systemd.volatile=overlay which overlaid all of / with a single tmpfs-backed overlayfs, set up /etc and /var separately:

- /etc: overlayfs with tmpfs upper (transient changes, lost on reboot)
- /var: real tmpfs with content copied from image (not overlayfs)

The key benefit is that /var is now a real tmpfs, allowing podman to use overlayfs for container storage inside /var/lib/containers. With the old approach, the nested overlayfs caused "too many levels of symbolic links" errors.

Implementation uses systemd credentials to inject units that run in the initramfs before switch-root:
- sysroot-etc.mount: overlay on /sysroot/etc
- bcvk-var-ephemeral.service: copies /sysroot/var to tmpfs and bind mounts

Both units use ConditionPathExists=/etc/initrd-release to only run in the initramfs context.

This is Phase 1 of issue #22, making ephemeral VMs more bootc-like. SELinux is still disabled (selinux=0); Phase 2 will add composefs support to enable proper SELinux labeling.

xref: #22 (Phase 1)
Assisted-by: OpenCode (Sonnet 4)