### PR TITLE
docs: Expand man pages with workflow examples and tips

### DIFF
--- a/docs/src/man/bcvk-ephemeral-run-ssh.md
+++ b/docs/src/man/bcvk-ephemeral-run-ssh.md
@@ -4,11 +4,36 @@ bcvk-ephemeral-run-ssh - Run ephemeral VM and SSH into it
 
 # SYNOPSIS
 
-**bcvk ephemeral run-ssh** [*OPTIONS*]
+**bcvk ephemeral run-ssh** \[*OPTIONS*\] *IMAGE* \[*SSH_ARGS*\]
 
 # DESCRIPTION
 
-Run ephemeral VM and SSH into it
+Run a bootc container as an ephemeral VM and immediately connect via SSH.
+When the SSH session ends, the VM is automatically stopped and cleaned up.
+
+This is the recommended command for quick testing and iteration. It combines
+**bcvk ephemeral run** and **bcvk ephemeral ssh** into a single command with
+automatic lifecycle management.
+
+## Lifecycle Behavior
+
+Unlike **bcvk ephemeral run -d** which starts a background VM that persists
+until explicitly stopped, **run-ssh** ties the VM lifecycle to the SSH session:
+
+1. VM boots and waits for SSH to become available
+2. SSH session is established
+3. When you exit the SSH session (or the connection drops), the VM is stopped
+4. The container is automatically removed
+
+This makes **run-ssh** ideal for:
+
+- Quick one-off testing of container images
+- Rapid build-test iteration cycles
+- Running a single command in a VM environment
+- Demos and exploration
+
+For longer-running VMs where you need to reconnect multiple times, use
+**bcvk ephemeral run -d --rm -K** instead.
 
 # OPTIONS
 
@@ -125,25 +150,83 @@ Run ephemeral VM and SSH into it
 
 # EXAMPLES
 
-Run an ephemeral VM and automatically SSH into it (VM cleans up when SSH exits):
+## Basic Usage
+
+Test a public bootc image:
 
     bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42
 
-Run a quick test with automatic SSH and cleanup:
+Test a CentOS bootc image:
 
-    bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42
+    bcvk ephemeral run-ssh quay.io/centos-bootc/centos-bootc:stream10
 
-Execute a specific command via SSH:
+## Build and Test Workflow
 
-    bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42 'systemctl status'
+The most common development pattern is building and immediately testing:
 
-Run with custom memory and CPU allocation:
+    # Build your container
+    podman build -t localhost/mybootc .
 
-    bcvk ephemeral run-ssh --memory 8G --vcpus 4 quay.io/fedora/fedora-bootc:42
+    # Boot it and SSH in (auto-cleanup on exit)
+    bcvk ephemeral run-ssh localhost/mybootc
+
+For rapid iteration, combine in one command:
+
+    podman build -t localhost/mybootc . && bcvk ephemeral run-ssh localhost/mybootc
+
+## Running Commands
+
+Execute a specific command and exit:
+
+    bcvk ephemeral run-ssh localhost/mybootc 'systemctl status'
+
+Check what services are running:
+
+    bcvk ephemeral run-ssh localhost/mybootc 'systemctl list-units --type=service --state=running'
+
+Verify your custom configuration:
+
+    bcvk ephemeral run-ssh localhost/mybootc 'cat /etc/myapp/config.yaml'
+
+## Resource Allocation
+
+For memory-intensive testing:
+
+    bcvk ephemeral run-ssh --memory 8G --vcpus 4 localhost/mybootc
+
+Using instance types:
+
+    bcvk ephemeral run-ssh --itype u1.medium localhost/mybootc
+
+## With Bind Mounts
+
+Mount source code for testing:
+
+    bcvk ephemeral run-ssh --bind /home/user/project:src localhost/mybootc
+    # Inside VM: ls /run/virtiofs-mnt-src
+
+## Debugging
+
+Enable console output to see boot messages:
+
+    bcvk ephemeral run-ssh --console localhost/mybootc
+
+# TIPS
+
+- **Fast iteration**: Keep your container builds small and layered for faster
+  rebuilds. The VM boots in seconds, so the container build is usually the
+  bottleneck.
+
+- **SSH arguments**: Any arguments after the image name are passed to SSH.
+  Use this for commands, port forwarding, or SSH options.
+
+- **Exit cleanly**: Use `exit` or Ctrl+D to cleanly end the SSH session and
+  trigger VM cleanup. Ctrl+C may not clean up properly.
 
 # SEE ALSO
 
-**bcvk**(8)
+**bcvk**(8), **bcvk-ephemeral**(8), **bcvk-ephemeral-run**(8),
+**bcvk-ephemeral-ssh**(8)
 
 # VERSION
 

--- a/docs/src/man/bcvk-ephemeral-ssh.md
+++ b/docs/src/man/bcvk-ephemeral-ssh.md
@@ -4,21 +4,42 @@ bcvk-ephemeral-ssh - Connect to running VMs via SSH
 
 # SYNOPSIS
 
-**bcvk ephemeral ssh** [*OPTIONS*]
+**bcvk ephemeral ssh** *CONTAINER_NAME* \[*SSH_ARGS*\]
 
 # DESCRIPTION
 
-Connect to running ephemeral VMs via SSH. This command provides SSH access to VMs created by **bcvk-ephemeral-run**(8).
+Connect to a running ephemeral VM via SSH. This command locates the VM's
+SSH port and connects using the SSH key that was injected when the VM
+was started with **-K** or **--ssh-keygen**.
 
-## VM Lifecycle Management
+## Prerequisites
 
-When using SSH with ephemeral VMs, the VM lifecycle can be bound to the SSH connection depending on how the VM was started:
+The target VM must have been started with SSH key injection:
 
-- **Background VMs** (started with `-d`): The VM continues running independently after SSH disconnection
-- **Interactive VMs** (started without `-d`): The VM terminates when SSH disconnects
-- **Auto-cleanup VMs** (started with `--rm`): The VM and container are automatically removed when the VM stops
+    bcvk ephemeral run -d --rm -K --name myvm image
 
-For the **bcvk-ephemeral-run-ssh**(8) command, the VM lifecycle is tightly coupled to the SSH session - when the SSH client terminates (e.g., by running `exit`), the entire VM and its container are automatically cleaned up.
+Without **-K**, the VM will not have SSH keys configured and this command
+will fail to authenticate.
+
+## How It Works
+
+1. Queries the podman container to find the VM's SSH port
+2. Retrieves the SSH private key from the container
+3. Connects using the dynamically assigned port and key
+4. Passes any additional arguments to the ssh client
+
+## VM Lifecycle
+
+SSH connections do not affect the VM lifecycle for background VMs:
+
+- **Background VMs** (started with **-d**): Continue running after SSH disconnect.
+  You can reconnect as many times as needed.
+- **Auto-cleanup VMs** (started with **--rm**): Container is removed when the VM
+  stops, but SSH disconnect alone does not stop the VM.
+
+To stop a background VM, use **podman stop**.
+
+For automatic cleanup on SSH exit, use **bcvk-ephemeral-run-ssh**(8) instead.
 
 # OPTIONS
 
@@ -37,38 +58,83 @@ For the **bcvk-ephemeral-run-ssh**(8) command, the VM lifecycle is tightly coupl
 
 # EXAMPLES
 
-Connect to a running ephemeral VM:
+## Basic Connection
 
-    bcvk ephemeral ssh mytestvm
+Connect to a running VM:
 
-Connect with SSH verbose mode:
+    bcvk ephemeral ssh myvm
 
-    bcvk ephemeral ssh mytestvm -v
+## Running Remote Commands
 
-Connect with port forwarding:
+Execute a command directly:
 
-    bcvk ephemeral ssh mytestvm -L 8080:localhost:80
+    bcvk ephemeral ssh myvm 'systemctl status'
 
-VM lifecycle examples:
+Check disk usage:
 
-    # Start a background VM (continues after SSH disconnect)
-    bcvk ephemeral run -d --name persistent-vm quay.io/fedora/fedora-bootc:42
-    bcvk ephemeral ssh persistent-vm
-    # VM keeps running after 'exit'
-    
-    # Start an auto-cleanup VM (removes when stopped)
-    bcvk ephemeral run -d --rm --name temp-vm quay.io/fedora/fedora-bootc:42
-    bcvk ephemeral ssh temp-vm
-    # VM and container auto-removed when VM stops
-    
-    # For tightly-coupled lifecycle, use run-ssh instead
-    bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42
-    # VM terminates automatically when SSH session ends
+    bcvk ephemeral ssh myvm 'df -h'
+
+View journal logs:
+
+    bcvk ephemeral ssh myvm 'journalctl -f'
+
+## SSH Options
+
+Enable verbose output for debugging connection issues:
+
+    bcvk ephemeral ssh myvm -v
+
+Forward a local port to the VM:
+
+    bcvk ephemeral ssh myvm -L 8080:localhost:80
+    # Access VM's port 80 at localhost:8080
+
+Reverse port forwarding (expose host port to VM):
+
+    bcvk ephemeral ssh myvm -R 3000:localhost:3000
+
+## Typical Workflow
+
+    # Start a VM in the background
+    bcvk ephemeral run -d --rm -K --name testvm quay.io/fedora/fedora-bootc:42
+
+    # Connect and do some work
+    bcvk ephemeral ssh testvm
+    # ... interactive session ...
+    # exit
+
+    # Reconnect later
+    bcvk ephemeral ssh testvm
+
+    # Run a quick command without interactive session
+    bcvk ephemeral ssh testvm 'cat /etc/os-release'
+
+    # Stop the VM when done
+    podman stop testvm
+
+## File Transfer
+
+Use scp-style operations by getting the SSH details:
+
+    # For now, use podman exec for file transfer
+    podman cp localfile testvm:/path/in/container
+
+    # Or mount a shared directory when starting the VM
+    bcvk ephemeral run -d --rm -K --bind /host/path:shared --name vm image
+
+# TROUBLESHOOTING
+
+**Connection refused**: The VM may still be booting. Wait a few seconds and retry.
+
+**Permission denied**: Ensure the VM was started with **-K** for SSH key injection.
+
+**Host key verification failed**: Each VM gets a unique host key. Use **-o StrictHostKeyChecking=no** if needed.
 
 # SEE ALSO
 
-**bcvk**(8), **bcvk-ephemeral**(8), **bcvk-ephemeral-run**(8), **bcvk-ephemeral-run-ssh**(8)
+**bcvk**(8), **bcvk-ephemeral**(8), **bcvk-ephemeral-run**(8),
+**bcvk-ephemeral-run-ssh**(8), **ssh**(1)
 
 # VERSION
 
-v0.1.0
+<!-- VERSION PLACEHOLDER -->

--- a/docs/src/man/bcvk-ephemeral.md
+++ b/docs/src/man/bcvk-ephemeral.md
@@ -4,32 +4,126 @@ bcvk-ephemeral - Manage ephemeral VMs for bootc containers
 
 # SYNOPSIS
 
-**bcvk ephemeral** [*OPTIONS*]
+**bcvk ephemeral** \<*SUBCOMMAND*\>
 
 # DESCRIPTION
 
-Manage ephemeral VMs for bootc containers
+Manage stateless VMs for bootc container images.
+
+Ephemeral VMs are managed by podman and boot directly from the container
+image's filesystem. Unlike libvirt VMs created with **bcvk-libvirt-run**(8),
+ephemeral VMs:
+
+- **Boot directly from the container image** via virtiofs (no disk image creation)
+- **Start in seconds** rather than minutes
+- **Are stateless by default** - filesystem changes don't persist across restarts
+- **Are managed via podman** - use familiar container tooling
+
+This makes ephemeral VMs ideal for local development, CI pipelines, and any
+workflow where you want fast iteration without persistent state.
+
+## How It Works
+
+Ephemeral VMs use a container-in-container architecture:
+
+1. A podman container is launched containing QEMU and virtiofsd
+2. The bootc container image's filesystem is shared into the VM via virtiofs
+3. The VM boots using the kernel and initramfs from the container image
+4. SSH access is provided via dynamically generated keys
+
+The host needs /dev/kvm access and a virtualization stack (qemu, virtiofsd).
 
 <!-- BEGIN GENERATED OPTIONS -->
 <!-- END GENERATED OPTIONS -->
 
+# SUBCOMMANDS
+
+bcvk-ephemeral-run(8)
+
+:   Run a bootc container as an ephemeral VM
+
+bcvk-ephemeral-run-ssh(8)
+
+:   Run an ephemeral VM and immediately SSH into it (auto-cleanup on exit)
+
+bcvk-ephemeral-ssh(8)
+
+:   SSH into a running ephemeral VM
+
+bcvk-ephemeral-ps(8)
+
+:   List running ephemeral VMs
+
+bcvk-ephemeral-rm-all(8)
+
+:   Remove all ephemeral VM containers
+
 # EXAMPLES
 
-Run an ephemeral VM in the background:
+## Quick Interactive Session
 
-    bcvk ephemeral run -d --rm --name mytestvm quay.io/fedora/fedora-bootc:42
+The simplest way to boot a bootc image is **run-ssh**, which starts the VM
+and drops you into an SSH session. When you exit, the VM is cleaned up:
 
-Run an ephemeral VM with custom resources:
+    bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42
 
-    bcvk ephemeral run --memory 4096 --cpus 4 --name bigvm quay.io/fedora/fedora-bootc:42
+## Build and Test Workflow
 
-Run an ephemeral VM with automatic SSH key generation:
+A typical development loop combines podman build with ephemeral testing:
 
+    # Edit your Containerfile
+    vim Containerfile
+
+    # Build the image
+    podman build -t localhost/mybootc .
+
+    # Test it immediately
+    bcvk ephemeral run-ssh localhost/mybootc
+
+    # Iterate: edit, build, test again
+    podman build -t localhost/mybootc . && bcvk ephemeral run-ssh localhost/mybootc
+
+## Background VM with SSH Access
+
+For longer sessions or when you need to reconnect, run the VM in the background:
+
+    # Start VM in background with SSH keys and auto-cleanup
     bcvk ephemeral run -d --rm -K --name testvm quay.io/fedora/fedora-bootc:42
+
+    # SSH into it (can reconnect multiple times)
+    bcvk ephemeral ssh testvm
+
+    # Run commands directly
+    bcvk ephemeral ssh testvm 'systemctl status'
+
+    # Stop when done (--rm ensures cleanup)
+    podman stop testvm
+
+## Development VM with Host Directory Access
+
+Mount your source code into the VM for development:
+
+    bcvk ephemeral run -d --rm -K \
+        --bind /home/user/project:project \
+        --name devvm localhost/mybootc
+
+    bcvk ephemeral ssh devvm
+    # Inside VM: cd /run/virtiofs-mnt-project
+
+## Resource Customization
+
+Allocate more resources for heavy workloads:
+
+    bcvk ephemeral run-ssh --memory 8G --vcpus 4 localhost/mybootc
+
+Or use instance types:
+
+    bcvk ephemeral run-ssh --itype u1.medium localhost/mybootc
 
 # SEE ALSO
 
-**bcvk**(8)
+**bcvk**(8), **bcvk-ephemeral-run**(8), **bcvk-ephemeral-run-ssh**(8),
+**bcvk-ephemeral-ssh**(8), **bcvk-libvirt**(8)
 
 # VERSION
 

--- a/docs/src/man/bcvk.md
+++ b/docs/src/man/bcvk.md
@@ -8,30 +8,62 @@ bcvk - A toolkit for bootable containers and (local) virtualization.
 
 # DESCRIPTION
 
-bcvk helps launch bootc containers using local virtualization.
-Build containers using your tool of choice (podman, docker, etc),
-then use `bcvk libvirt run` to quickly and conveniently create
-a libvirt virtual machine, and connect with `ssh`.
+bcvk helps launch bootc containers using local virtualization for
+development and CI workflows. Build containers using your tool of choice
+(podman, docker, etc), then use bcvk to boot them as virtual machines.
 
-The toolkit includes commands for:
+Note: bcvk is designed for local development and CI environments, not for
+running production servers.
 
-- Running ephemeral VMs for testing container images
-- Installing bootc containers to persistent disk images
-- Managing libvirt integration and VM lifecycle
-- SSH access to running VMs
+## Quick Start
+
+The fastest way to boot a bootc container image is with **bcvk ephemeral run-ssh**:
+
+    bcvk ephemeral run-ssh quay.io/fedora/fedora-bootc:42
+
+This boots the container as a VM and drops you into an SSH session. When you
+exit the SSH session, the VM is automatically cleaned up.
+
+## Build and Test Workflow
+
+A typical development workflow combines container builds with ephemeral VM testing:
+
+    # Build your bootc container
+    podman build -t localhost/myimage .
+
+    # Boot it as a VM and SSH in (auto-cleanup on exit)
+    bcvk ephemeral run-ssh localhost/myimage
+
+    # Or run in background for longer testing
+    bcvk ephemeral run -d --rm -K --name testvm localhost/myimage
+    bcvk ephemeral ssh testvm
+    # ... test, then stop the VM when done
+    podman stop testvm
+
+## Ephemeral vs Libvirt
+
+bcvk provides two ways to run bootc containers as VMs:
+
+**bcvk ephemeral** runs stateless VMs managed by podman. The VM boots directly
+from the container image's filesystem via virtiofs with no disk image creation,
+making startup very fast. Ideal for quick iteration and CI pipelines.
+
+**bcvk libvirt** creates stateful VMs managed by libvirt with persistent disk
+images. These VMs survive reboots and support the full bootc upgrade workflow.
+Useful for longer-running local development or testing upgrade scenarios.
 
 <!-- BEGIN GENERATED OPTIONS -->
 <!-- END GENERATED OPTIONS -->
 
 # SUBCOMMANDS
 
+bcvk-ephemeral(8)
+
+:   Manage stateless VMs via podman (fast startup, no disk images)
+
 bcvk-images(8)
 
 :   Manage and inspect bootc container images
-
-bcvk-run-ephemeral(8)
-
-:   Run bootc containers as temporary VMs for testing and development
 
 bcvk-to-disk(8)
 
@@ -39,16 +71,34 @@ bcvk-to-disk(8)
 
 bcvk-libvirt(8)
 
-:   Manage libvirt integration for bootc containers
+:   Manage stateful VMs via libvirt (persistent disk images)
 
-bcvk-ssh(8)
+# EXAMPLES
 
-:   Connect to running VMs via SSH
+Test a public bootc image interactively:
 
-bcvk-help(8)
+    bcvk ephemeral run-ssh quay.io/centos-bootc/centos-bootc:stream10
 
-:   Print this message or the help of the given subcommand(s)
+Build and test a local image:
+
+    podman build -t localhost/mybootc .
+    bcvk ephemeral run-ssh localhost/mybootc
+
+Run a background VM with SSH access:
+
+    bcvk ephemeral run -d --rm -K --name dev quay.io/fedora/fedora-bootc:42
+    bcvk ephemeral ssh dev
+
+Create a libvirt VM with persistent disk:
+
+    bcvk libvirt run --name myvm quay.io/centos-bootc/centos-bootc:stream10
+    bcvk libvirt ssh myvm
+
+# SEE ALSO
+
+**bcvk-ephemeral**(8), **bcvk-ephemeral-run**(8), **bcvk-ephemeral-run-ssh**(8),
+**bcvk-libvirt**(8), **bcvk-to-disk**(8), **bootc**(8)
 
 # VERSION
 
-v0.1.0
+<!-- VERSION PLACEHOLDER -->


### PR DESCRIPTION
Our man pages were pretty dry; let's include more background information in them, and clarify things more.

Assisted-by: OpenCode (Sonnet 4)