### PR TITLE
install: Add `bootloader` option

### DIFF
--- a/crates/kit/src/install_options.rs
+++ b/crates/kit/src/install_options.rs
@@ -40,6 +40,10 @@ pub struct InstallOptions {
     /// Default to composefs-native storage
     #[clap(long)]
     pub composefs_backend: bool,
+
+    /// Which bootloader to use for composefs-native backend
+    #[clap(long, requires = "composefs_backend")]
+    pub bootloader: Option<String>,
 }
 
 impl InstallOptions {
@@ -68,6 +72,11 @@ impl InstallOptions {
 
         if self.composefs_backend {
             args.push("--composefs-backend".to_owned());
+        }
+
+        if let Some(b) = &self.bootloader {
+            args.push("--bootloader".into());
+            args.push(b.clone());
         }
 
         args


### PR DESCRIPTION
For composefs backend we'd sometimes want to override the bootloader. Currently we have logic that check if an image has bootupd or not, and if it does we use grub as the bootloader, even if systemd-boot is actually installed

We use this option to override the bootloader