### PR TITLE
libvirt: Add opt-in --graphical-console flag for SPICE display

### DIFF
--- a/crates/kit/src/libvirt/domain.rs
+++ b/crates/kit/src/libvirt/domain.rs
@@ -43,7 +43,7 @@ pub struct DomainBuilder {
     disk_path: Option<String>,
     transient_disk: bool, // Use transient disk with temporary overlay
     network: Option<String>,
-    vnc_port: Option<u16>,
+    graphical_console: bool,
     kernel_args: Option<String>,
     metadata: HashMap<String, String>,
     qemu_args: Vec<String>,
@@ -76,7 +76,7 @@ impl DomainBuilder {
             disk_path: None,
             transient_disk: false,
             network: None,
-            vnc_port: None,
+            graphical_console: false,
             kernel_args: None,
             metadata: HashMap::new(),
             qemu_args: Vec::new(),
@@ -129,10 +129,9 @@ impl DomainBuilder {
         self
     }
 
-    /// Enable VNC on specified port
-    #[allow(dead_code)]
-    pub fn with_vnc(mut self, port: u16) -> Self {
-        self.vnc_port = Some(port);
+    /// Enable graphical console (SPICE) for virt-manager access
+    pub fn with_graphical_console(mut self) -> Self {
+        self.graphical_console = true;
         self
     }
 
@@ -474,19 +473,23 @@ impl DomainBuilder {
             }
         }
 
-        // VNC graphics if enabled
-        if let Some(vnc_port) = self.vnc_port {
-            writer.write_empty_element(
-                "graphics",
-                &[
-                    ("type", "vnc"),
-                    ("port", &vnc_port.to_string()),
-                    ("listen", "127.0.0.1"),
-                ],
-            )?;
+        // Graphical console (SPICE) for virt-manager access
+        if self.graphical_console {
+            writer.start_element("graphics", &[("type", "spice"), ("autoport", "yes")])?;
+            writer.write_empty_element("listen", &[("type", "address")])?;
+            writer.end_element("graphics")?;
             writer.start_element("video", &[])?;
-            writer.write_empty_element("model", &[("type", "vga")])?;
+            writer.write_empty_element(
+                "model",
+                &[("type", "virtio"), ("heads", "1"), ("primary", "yes")],
+            )?;
             writer.end_element("video")?;
+            writer.start_element("channel", &[("type", "spicevmc")])?;
+            writer.write_empty_element(
+                "target",
+                &[("type", "virtio"), ("name", "com.redhat.spice.0")],
+            )?;
+            writer.end_element("channel")?;
         }
 
         // Virtiofs filesystems
@@ -633,15 +636,28 @@ mod tests {
     }
 
     #[test]
-    fn test_vnc_configuration() {
+    fn test_graphical_console_configuration() {
+        // Test with graphical console enabled
         let xml = DomainBuilder::new()
             .with_name("test")
-            .with_vnc(5901)
+            .with_graphical_console()
             .build_xml()
             .unwrap();
 
-        assert!(xml.contains("graphics type=\"vnc\" port=\"5901\""));
-        assert!(xml.contains("model type=\"vga\""));
+        assert!(xml.contains("graphics type=\"spice\" autoport=\"yes\""));
+        assert!(xml.contains("model type=\"virtio\" heads=\"1\" primary=\"yes\""));
+        assert!(xml.contains("channel type=\"spicevmc\""));
+        assert!(xml.contains("target type=\"virtio\" name=\"com.redhat.spice.0\""));
+
+        // Test without graphical console (default)
+        let xml_no_graphics = DomainBuilder::new()
+            .with_name("test-no-graphics")
+            .build_xml()
+            .unwrap();
+
+        assert!(!xml_no_graphics.contains("<graphics"));
+        assert!(!xml_no_graphics.contains("<video"));
+        assert!(!xml_no_graphics.contains("spicevmc"));
     }
 
     #[test]

--- a/crates/kit/src/libvirt/domain.rs
+++ b/crates/kit/src/libvirt/domain.rs
@@ -43,7 +43,7 @@ pub struct DomainBuilder {
     disk_path: Option<String>,
     transient_disk: bool, // Use transient disk with temporary overlay
     network: Option<String>,
-    vnc_port: Option<u16>,
+    graphical_console: bool,
     kernel_args: Option<String>,
     metadata: HashMap<String, String>,
     qemu_args: Vec<String>,
@@ -78,7 +78,7 @@ impl DomainBuilder {
             disk_path: None,
             transient_disk: false,
             network: None,
-            vnc_port: None,
+            graphical_console: false,
             kernel_args: None,
             metadata: HashMap::new(),
             qemu_args: Vec::new(),
@@ -133,10 +133,9 @@ impl DomainBuilder {
         self
     }
 
-    /// Enable VNC on specified port
-    #[allow(dead_code)]
-    pub fn with_vnc(mut self, port: u16) -> Self {
-        self.vnc_port = Some(port);
+    /// Enable graphical console (SPICE) for virt-manager access
+    pub fn with_graphical_console(mut self) -> Self {
+        self.graphical_console = true;
         self
     }
 
@@ -498,19 +497,23 @@ impl DomainBuilder {
             }
         }
 
-        // VNC graphics if enabled
-        if let Some(vnc_port) = self.vnc_port {
-            writer.write_empty_element(
-                "graphics",
-                &[
-                    ("type", "vnc"),
-                    ("port", &vnc_port.to_string()),
-                    ("listen", "127.0.0.1"),
-                ],
-            )?;
+        // Graphical console (SPICE) for virt-manager access
+        if self.graphical_console {
+            writer.start_element("graphics", &[("type", "spice"), ("autoport", "yes")])?;
+            writer.write_empty_element("listen", &[("type", "address")])?;
+            writer.end_element("graphics")?;
             writer.start_element("video", &[])?;
-            writer.write_empty_element("model", &[("type", "vga")])?;
+            writer.write_empty_element(
+                "model",
+                &[("type", "virtio"), ("heads", "1"), ("primary", "yes")],
+            )?;
             writer.end_element("video")?;
+            writer.start_element("channel", &[("type", "spicevmc")])?;
+            writer.write_empty_element(
+                "target",
+                &[("type", "virtio"), ("name", "com.redhat.spice.0")],
+            )?;
+            writer.end_element("channel")?;
         }
 
         // Virtiofs filesystems
@@ -657,15 +660,28 @@ mod tests {
     }
 
     #[test]
-    fn test_vnc_configuration() {
+    fn test_graphical_console_configuration() {
+        // Test with graphical console enabled
         let xml = DomainBuilder::new()
             .with_name("test")
-            .with_vnc(5901)
+            .with_graphical_console()
             .build_xml()
             .unwrap();
 
-        assert!(xml.contains("graphics type=\"vnc\" port=\"5901\""));
-        assert!(xml.contains("model type=\"vga\""));
+        assert!(xml.contains("graphics type=\"spice\" autoport=\"yes\""));
+        assert!(xml.contains("model type=\"virtio\" heads=\"1\" primary=\"yes\""));
+        assert!(xml.contains("channel type=\"spicevmc\""));
+        assert!(xml.contains("target type=\"virtio\" name=\"com.redhat.spice.0\""));
+
+        // Test without graphical console (default)
+        let xml_no_graphics = DomainBuilder::new()
+            .with_name("test-no-graphics")
+            .build_xml()
+            .unwrap();
+
+        assert!(!xml_no_graphics.contains("<graphics"));
+        assert!(!xml_no_graphics.contains("<video"));
+        assert!(!xml_no_graphics.contains("spicevmc"));
     }
 
     #[test]

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -297,6 +297,10 @@ pub struct LibvirtRunOpts {
     #[clap(long)]
     pub label: Vec<String>,
 
+    /// Enable graphical console (SPICE) for virt-manager access
+    #[clap(long)]
+    pub graphical_console: bool,
+
     /// Create a transient VM that disappears on shutdown/reboot
     #[clap(long)]
     pub transient: bool,
@@ -471,6 +475,12 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, mut opts: LibvirtRunOpt
     if opts.update_from_host {
         opts.bind_storage_ro = true;
         opts.install.target_transport = Some(UPDATE_FROM_HOST_TRANSPORT.to_owned());
+    }
+
+    // Add console=tty1 kernel argument for graphical console support
+    if opts.graphical_console {
+        opts.install.karg.push("console=tty1".to_string());
+        debug!("Added console=tty1 kernel argument for graphical console");
     }
 
     // Add Ignition kernel argument to install options if Ignition config is specified
@@ -1192,6 +1202,9 @@ fn create_libvirt_domain_from_disk(
     if opts.firmware_log {
         domain_builder =
             domain_builder.with_firmware_log(crate::libvirt::domain::FirmwareLogOutput::Console);
+    }
+    if opts.graphical_console {
+        domain_builder = domain_builder.with_graphical_console();
     }
     domain_builder = domain_builder
         .with_metadata("bootc:source-image", &opts.image)

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -297,6 +297,10 @@ pub struct LibvirtRunOpts {
     #[clap(long)]
     pub label: Vec<String>,
 
+    /// Enable graphical console (SPICE) for virt-manager access
+    #[clap(long)]
+    pub graphical_console: bool,
+
     /// Create a transient VM that disappears on shutdown/reboot
     #[clap(long)]
     pub transient: bool,
@@ -1208,6 +1212,9 @@ fn create_libvirt_domain_from_disk(
     if opts.firmware_log {
         domain_builder =
             domain_builder.with_firmware_log(crate::libvirt::domain::FirmwareLogOutput::Console);
+    }
+    if opts.graphical_console {
+        domain_builder = domain_builder.with_graphical_console();
     }
     domain_builder = domain_builder
         .with_metadata("bootc:source-image", &opts.image)


### PR DESCRIPTION
Add a --graphical-console flag to 'bcvk libvirt run' that enables a
SPICE graphics console for virt-manager access. When enabled, the domain
XML includes a SPICE display with autoport, a virtio GPU, and a spicevmc
channel for clipboard and display resize support.

This also removes unused VNC support code.

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: John Eckersberg <jeckersb@redhat.com>
