### PR TITLE
Publish development binaries as OCI artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,39 @@ jobs:
             target/bcvk-*.tar.gz.sha256
           retention-days: 7
 
+  publish-binary:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Install ORAS CLI
+        run: |
+          # renovate: datasource=github-releases depName=oras-project/oras
+          VERSION=1.2.2
+          curl -LO https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz
+          tar -xzf oras_${VERSION}_linux_amd64.tar.gz
+          sudo mv oras /usr/local/bin/
+
+      - name: Download bcvk binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bcvk-binary
+
+      - name: Login to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io --username ${{ github.repository_owner }} --password-stdin
+
+      - name: Push binary as OCI artifact
+        run: |
+          for file in bcvk-*.tar.gz; do
+            ARCH=$(echo "$file" | sed 's/bcvk-\(.*\)-unknown-linux-gnu\.tar\.gz/\1/')
+            oras push "ghcr.io/bootc-dev/bcvk-binary:${ARCH}-latest" "$file:application/gzip" "${file}.sha256:text/plain"
+          done
+
   integration-tests:
     runs-on: ubuntu-24.04
     needs: build

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -16,6 +16,18 @@ Optional:
   sudo usermod -a -G libvirt $USER
   ```
 
+## Development Binaries
+
+Pre-built binaries from `main` are available as OCI artifacts:
+
+```bash
+# Requires ORAS (https://oras.land/)
+# Note: This command pulls the x86_64 architecture binary
+oras pull ghcr.io/bootc-dev/bcvk-binary:x86_64-latest
+tar -xzf bcvk-x86_64-unknown-linux-gnu.tar.gz
+sudo install -m 755 bcvk-x86_64-unknown-linux-gnu /usr/local/bin/bcvk
+```
+
 ## Building from Source
 
 Without cloning the repo:


### PR DESCRIPTION
Adds GitHub workflow to publish bcvk binaries from main branch to ghcr.io/bootc-dev/bcvk-binary as OCI artifacts. This enables testing unreleased features in downstream CI (like bootc) without building from the source.
Binaries can be pulled with: oras pull ghcr.io/bootc-dev/bcvk-binary:x86_64-latest 

Fixes: #181
Assisted-by: Claude Code (Sonnet 4.5)