### PR TITLE
composefs: add check for UKI

### DIFF
--- a/crates/kit/src/images.rs
+++ b/crates/kit/src/images.rs
@@ -216,6 +216,14 @@ pub fn get_image_size(name: &str) -> Result<u64> {
     Ok(info.size)
 }
 
+/// Check if image has a UKI (required for --composefs-backend)
+pub fn has_uki(name: &str) -> Result<bool> {
+    let status = Command::new("podman")
+        .args(["run", "--rm", name, "sh", "-c", "ls /boot/EFI/Linux/*.efi >/dev/null 2>&1"])
+        .status()?;
+    Ok(status.success())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kit/src/to_disk.rs
+++ b/crates/kit/src/to_disk.rs
@@ -369,6 +369,13 @@ EOF
 /// Main entry point for the bootc installation process. See module-level documentation
 /// for details on the installation workflow and architecture.
 pub fn run(opts: ToDiskOpts) -> Result<()> {
+    if opts.install.composefs_backend && !images::has_uki(&opts.source_image)? {
+        return Err(eyre!(
+            "Image '{}' has no UKI - not suitable for --composefs-backend",
+            opts.source_image
+        ));
+    }
+
     // Phase 0: Check for existing cached disk image
     let would_reuse = if opts.target_disk.exists() {
         debug!(


### PR DESCRIPTION
when --composefs-backend is used, make sure there is a UKI in the specified image.

Assisted-by: Claude Code (Sonnet 4.5)