### PR TITLE
qemu: Add --allow-mmap to virtiofsd for mmap support

### DIFF
--- a/crates/kit/src/qemu.rs
+++ b/crates/kit/src/qemu.rs
@@ -923,8 +923,12 @@ pub async fn spawn_virtiofsd_async(config: &VirtiofsConfig) -> Result<tokio::pro
         config.socket_path.as_str(),
         "--shared-dir",
         config.shared_dir.as_str(),
-        // Ensure we don't hit fd exhaustion
+        // Ensure we don't hit fd exhaustion; see commit 50e7601.
         "--cache=never",
+        // Allowing mmap is needed in the general case for loading shared libraries
+        // etc. This flag negotiates FUSE_DIRECT_IO_ALLOW_MMAP with the kernel (requires kernel 6.2+).
+        // Per the documentation this is safe because the underlying filesystem tree is immutable.
+        "--allow-mmap",
         // We always run in a container
         "--sandbox=none",
     ]);


### PR DESCRIPTION
The --cache=never flag (added in 50e7601 to avoid FD exhaustion) has a side effect: the guest kernel returns ENODEV for mmap() syscalls on virtiofs files. This breaks nontrivial use cases; while glibc has a fallback for failure to `mmap()` other tools don't.

Assisted-by: OpenCode (claude-sonnet-4-20250514)