### PR TITLE
credentials: Use remote-fs.target for virtiofs mount ordering

### DIFF
--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -1244,14 +1244,15 @@ fn create_libvirt_domain_from_disk(
         );
     }
 
-    // Create a single dropin for local-fs.target that wants all mount units
-    // This must be done AFTER all mount units have been added (including bind-storage-ro)
+    // Create a dropin for remote-fs.target that wants all virtiofs mount units.
+    // We use remote-fs.target because virtiofs is conceptually similar to a remote
+    // filesystem - it requires virtio transport infrastructure, like NFS needs network.
     if !mount_unit_names.is_empty() {
         let wants_list = mount_unit_names.join(" ");
         let dropin_content = format!("[Unit]\nWants={}\n", wants_list);
         let encoded_dropin = data_encoding::BASE64.encode(dropin_content.as_bytes());
         let dropin_cred = format!(
-            "io.systemd.credential.binary:systemd.unit-dropin.local-fs.target~bcvk-mounts={encoded_dropin}"
+            "io.systemd.credential.binary:systemd.unit-dropin.remote-fs.target~bcvk-mounts={encoded_dropin}"
         );
         smbios_creds.push(dropin_cred);
     }


### PR DESCRIPTION
The original mount unit configuration used Before=local-fs.target, which could cause issues with virtiofs mounts that depend on virtio transport infrastructure being available.

Change the mount units to use Before=remote-fs.target instead. This is more appropriate because virtiofs is conceptually similar to a remote filesystem - it requires external infrastructure (virtio transport) to be available, similar to how NFS requires network connectivity.

This follows systemd conventions where remote-fs.target is used for filesystems that depend on infrastructure beyond the local disk.

Assisted-by: OpenCode (Claude claude-opus-4-5-20250114)