### PR TITLE
docs: Add dnf installation step

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,5 +1,13 @@
 # Installation
 
+## From Packages
+
+bcvk is available in Fedora 42+ and EPEL 9/10:
+
+```bash
+sudo dnf install bcvk
+```
+
 ## Prerequisites
 
 Required:


### PR DESCRIPTION
Now that we have bcvk in testing/stable for Fedora 42+ and EPEL9/10, we can add the installation process with dnf.
Package: https://koji.fedoraproject.org/koji/packageinfo?packageID=43081 