### PR TITLE
spec: Use ExclusiveArch for supported architectures

### DIFF
--- a/contrib/packaging/bcvk.spec
+++ b/contrib/packaging/bcvk.spec
@@ -11,8 +11,8 @@ URL:            https://github.com/bootc-dev/bcvk
 Source0:        %{url}/releases/download/v%{version}/bcvk-%{version}.tar.zstd
 Source1:        %{url}/releases/download/v%{version}/bcvk-%{version}-vendor.tar.zstd
 
-# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
-ExcludeArch:    %{ix86}
+# Only build for architectures with full support and testing
+ExclusiveArch:  x86_64 aarch64
 
 Requires: binutils
 Requires: openssh-clients


### PR DESCRIPTION
Only build RPM packages for x86_64 and aarch64, which are the architectures with full support and testing. This prevents build failures on ppc64le/s390x where the unit tests fail. This doesn't block developers from building with cargo on any architecture for local experimentation.