### PR TITLE
packit: Add CentOS Stream dist-git branches

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -55,11 +55,15 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-all
+      - c9s
+      - c10s
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-all
+      - c9s
+      - c10s
 
   - job: bodhi_update
     trigger: commit


### PR DESCRIPTION
This should've been included in last PR but let's configure packit to propose updates to CentOS Stream 9 and 10 dist-git repositories and trigger Koji builds on commits.