### PR TITLE
libvirt: Disable firmware debug log (isa-debugcon) by default

### DIFF
--- a/crates/integration-tests/src/tests/libvirt_verb.rs
+++ b/crates/integration-tests/src/tests/libvirt_verb.rs
@@ -686,7 +686,21 @@ fn test_libvirt_run_no_storage_opts_without_bind_storage() -> Result<()> {
         "Domain XML should NOT contain bind-storage-ro metadata when flag is not used. Found in XML."
     );
     println!("✓ Domain XML does not contain bind-storage-ro metadata");
-    println!("✓ Test passed: STORAGE_OPTS credentials are correctly excluded when --bind-storage-ro is not used");
+
+    // Verify that firmware debug log (isa-debugcon) is NOT present by default.
+    // Verbose OVMF firmware causes debug spam (e.g. VirtioSerialIoGetControl)
+    // when this device is present, so it must be opt-in via --firmware-log.
+    if std::env::consts::ARCH == "x86_64" {
+        assert!(
+            !domain_xml.contains("isa-debugcon"),
+            "Domain XML should NOT contain isa-debugcon by default (use --firmware-log to enable)"
+        );
+        println!(
+            "✓ Domain XML does not contain isa-debugcon (firmware debug log disabled by default)"
+        );
+    }
+
+    println!("✓ Test passed: default domain config has no unexpected extras");
     Ok(())
 }
 integration_test!(test_libvirt_run_no_storage_opts_without_bind_storage);

--- a/crates/kit/src/libvirt/domain.rs
+++ b/crates/kit/src/libvirt/domain.rs
@@ -85,7 +85,7 @@ impl DomainBuilder {
             ovmf_code_format: None,
             nvram_template: None,
             nvram_format: None,
-            firmware_log: Some(FirmwareLogOutput::Console), // Default to pty for virsh console access
+            firmware_log: None,
         }
     }
 
@@ -775,58 +775,5 @@ mod tests {
         assert!(xml_ro.contains("<readonly/>"));
         assert!(xml_ro.contains("source dir=\"/host/storage\""));
         assert!(xml_ro.contains("target dir=\"hoststorage\""));
-    }
-
-    #[test]
-    fn test_firmware_log_default() {
-        // By default, firmware log should be enabled (pty/console mode)
-        let xml = DomainBuilder::new()
-            .with_name("test-firmware-log-default")
-            .build_xml()
-            .unwrap();
-
-        // On x86_64, should have isa-debugcon serial device
-        if std::env::consts::ARCH == "x86_64" {
-            assert!(xml.contains("serial type=\"pty\""));
-            assert!(xml.contains("target type=\"isa-debug\""));
-            assert!(xml.contains("model name=\"isa-debugcon\""));
-            assert!(xml.contains("address type=\"isa\" iobase=\"0x402\""));
-        }
-    }
-
-    #[test]
-    fn test_firmware_log_file() {
-        // Test firmware log to file
-        let xml = DomainBuilder::new()
-            .with_name("test-firmware-log-file")
-            .with_firmware_log(FirmwareLogOutput::File("/tmp/ovmf-debug.log".to_string()))
-            .build_xml()
-            .unwrap();
-
-        // On x86_64, should have isa-debugcon with file output
-        if std::env::consts::ARCH == "x86_64" {
-            assert!(xml.contains("serial type=\"file\""));
-            assert!(xml.contains("source path=\"/tmp/ovmf-debug.log\""));
-            assert!(xml.contains("target type=\"isa-debug\""));
-            assert!(xml.contains("model name=\"isa-debugcon\""));
-            assert!(xml.contains("address type=\"isa\" iobase=\"0x402\""));
-        }
-    }
-
-    #[test]
-    fn test_firmware_log_disabled() {
-        // Test disabling firmware log by setting firmware_log to None after construction
-        // Note: There's no public API to disable it once set, but we can test the XML
-        // generation doesn't include it on non-x86 architectures
-        let xml = DomainBuilder::new()
-            .with_name("test-firmware-log")
-            .build_xml()
-            .unwrap();
-
-        // On non-x86_64, should NOT have isa-debugcon (it's x86-only)
-        if std::env::consts::ARCH != "x86_64" {
-            assert!(!xml.contains("isa-debugcon"));
-            assert!(!xml.contains("isa-debug"));
-        }
     }
 }

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -285,6 +285,10 @@ pub struct LibvirtRunOpts {
     #[clap(long)]
     pub disable_tpm: bool,
 
+    /// Enable firmware debug log (captures OVMF/EDK2 DEBUG output via isa-debugcon)
+    #[clap(long)]
+    pub firmware_log: bool,
+
     /// Directory containing secure boot keys (required for uefi-secure)
     #[clap(long)]
     pub secure_boot_keys: Option<Utf8PathBuf>,
@@ -1099,7 +1103,12 @@ fn create_libvirt_domain_from_disk(
         .with_transient_disk(opts.transient)
         .with_network("none") // Use QEMU args for SSH networking instead
         .with_firmware(opts.firmware)
-        .with_tpm(!opts.disable_tpm)
+        .with_tpm(!opts.disable_tpm);
+    if opts.firmware_log {
+        domain_builder =
+            domain_builder.with_firmware_log(crate::libvirt::domain::FirmwareLogOutput::Console);
+    }
+    domain_builder = domain_builder
         .with_metadata("bootc:source-image", &opts.image)
         .with_metadata("bootc:memory-mb", &memory.to_string())
         .with_metadata("bootc:vcpus", &cpus.to_string())


### PR DESCRIPTION
Previously I added `isa-debugcon` when debugging a secure boot issue, but it slows down boot significantly if it's found. Make it an opt in thing.

Assisted-by: OpenCode (Claude Opus 4)