### PR TITLE
packit: Add EPEL branches for automated releases

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -53,17 +53,16 @@ jobs:
 
   - job: propose_downstream
     trigger: release
-    dist_git_branches:
+    dist_git_branches: &dist_git_branches
       - fedora-all
-      - c9s
-      - c10s
+      - epel9
+      - epel10.1
+      - epel10.2
+      - epel10.3
 
   - job: koji_build
     trigger: commit
-    dist_git_branches:
-      - fedora-all
-      - c9s
-      - c10s
+    dist_git_branches: *dist_git_branches
 
   - job: bodhi_update
     trigger: commit


### PR DESCRIPTION
Configure packit to automatically propose updates and trigger builds for EPEL 9 and EPEL 10.x (10.1, 10.2, 10.3) on  upstream releases. Removed CentOS Stream branches as bcvk is EPEL only as of now.
We can update this once we get a decision on RHEL extensions vs appstream inclusion for bcvk.