### PR TITLE
packit: remove inactive epel10.3

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -58,7 +58,6 @@ jobs:
       - epel9
       - epel10.1
       - epel10.2
-      - epel10.3
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
Remove EPEL-10.3 from packit as it is not active yet.
 
Closes: https://github.com/bootc-dev/bcvk/issues/228