### PR TITLE
Add early dependency checks and fix packaging

### DIFF
--- a/contrib/packaging/bcvk.spec
+++ b/contrib/packaging/bcvk.spec
@@ -14,7 +14,6 @@ Source1:        %{url}/releases/download/v%{version}/bcvk-%{version}-vendor.tar.
 # Only build for architectures with full support and testing
 ExclusiveArch:  x86_64 aarch64
 
-Requires: binutils
 Requires: openssh-clients
 Requires: podman
 Requires: qemu-img

--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -861,11 +861,15 @@ fn parse_service_exit_code(status_content: &str) -> Result<i32> {
     Ok(0)
 }
 
-/// Check for required binaries in the target container image
+/// Check for required binaries in the privileged container
 ///
-/// These binaries must be present in the container image being run as an ephemeral VM.
+/// These binaries must be present in the privileged container that runs bcvk,
+/// not the guest bootc image that gets booted inside the VM.
 fn check_required_container_binaries() -> Result<()> {
-    // We use systemctl in a few places. objcopy is for UKI extraction.
+    // systemctl: used for checking cloud-init and other systemd operations
+    // objcopy: for UKI kernel extraction (when using UKI images)
+    // NOTE: bwrap is checked earlier in entrypoint.sh, not here, because by the
+    // time run_impl() executes we're already inside the bwrap namespace
     let required_binaries = ["systemctl", "objcopy"];
 
     let mut missing = Vec::new();

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -10,12 +10,18 @@ sudo dnf install bcvk
 
 ## Prerequisites
 
-Required:
+### Host Requirements
+
+For building from source:
 - [Rust](https://www.rust-lang.org/)
 - Git
+
+For running bcvk:
 - QEMU/KVM
+- qemu-img
 - virtiofsd
 - Podman
+- openssh-clients (for libvirt SSH operations)
 
 Optional:
 - libvirt (for persistent VM features)
@@ -23,6 +29,14 @@ Optional:
   sudo systemctl enable --now libvirtd
   sudo usermod -a -G libvirt $USER
   ```
+
+### Target Bootc Image Requirements
+
+For `bcvk ephemeral` operations, the bootc container images you run must contain:
+- systemctl (systemd)
+- objcopy (binutils)
+- bwrap (bubblewrap)
+- ssh, ssh-keygen (openssh-clients)
 
 ## Development Binaries
 


### PR DESCRIPTION
- Check for bwrap/objcopy/systemctl early with clear errors                                                         
- Add missing bubblewrap to bcvk.spec
- Document all runtime dependencies 

Closes: https://github.com/bootc-dev/bcvk/issues/250