### PR TITLE
Updates for Fedora 44 release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -40,6 +40,8 @@ jobs:
       - centos-stream-10-aarch64
       - fedora-43-x86_64
       - fedora-43-aarch64
+      - fedora-44-x86_64
+      - fedora-44-aarch64
       - fedora-rawhide-x86_64
       - fedora-rawhide-aarch64
 

--- a/crates/integration-tests/fixtures/Dockerfile.uki-only
+++ b/crates/integration-tests/fixtures/Dockerfile.uki-only
@@ -11,11 +11,11 @@
 #
 # Note: This requires ukify and systemd-boot packages in the base image.
 
-ARG BASE_IMAGE=ghcr.io/bootc-dev/dev-bootc:fedora-43-uki
+ARG BASE_IMAGE=ghcr.io/bootc-dev/dev-bootc:fedora-44-uki
 
 FROM ${BASE_IMAGE} AS builder
 
-# Install ukify if not present (should be in fedora-43-uki)
+# Install ukify if not present (should be in fedora-44-uki)
 RUN command -v ukify || dnf install -y systemd-ukify
 
 # Build UKI and place it in the standard /boot/EFI/Linux/ location


### PR DESCRIPTION
- Add fedora-44 to packit copr builds
- Update integration to use fedora-44 instead of fedora-43

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
