### PR TITLE
docs: Fix incorrect flag in to-disk example

### DIFF
--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -35,7 +35,7 @@ bcvk to-disk quay.io/centos-bootc/centos-bootc:stream10 /path/to/disk.img
 bcvk to-disk --format qcow2 quay.io/fedora/fedora-bootc:42 /path/to/fedora.qcow2
 
 # Custom size
-bcvk to-disk --size 20G quay.io/fedora/fedora-bootc:42 /path/to/large-disk.img
+bcvk to-disk --disk-size 20G quay.io/fedora/fedora-bootc:42 /path/to/large-disk.img
 ```
 
 ## Persistent VMs with libvirt


### PR DESCRIPTION
The quick-start guide showed using `--size 20G` with `bcvk to-disk`,but the correct flag is `--disk-size`. This was likely a typo as the libvirt example in the same file correctly uses `--disk-size`.
