### PR TITLE
libvirt: Set LC_ALL=C for virsh commands

### DIFF
--- a/crates/integration-tests/src/tests/libvirt_verb.rs
+++ b/crates/integration-tests/src/tests/libvirt_verb.rs
@@ -265,7 +265,7 @@ fn test_libvirt_comprehensive_workflow() -> TestResult {
 
     // Test 5: Verify VM lifecycle (already running, test inspect)
     println!("Test 5: Verifying VM is running...");
-    let info = cmd!(sh, "virsh dominfo {domain_name}").read()?;
+    let info = cmd!(sh, "env LC_ALL=C virsh dominfo {domain_name}").read()?;
     assert!(
         info.contains("running") || info.contains("idle"),
         "Domain should be running"
@@ -277,7 +277,7 @@ fn test_libvirt_comprehensive_workflow() -> TestResult {
     let rm_test_domain = create_test_vm_and_assert("test-rm", &test_image)?;
 
     // Verify it's running
-    let rm_info = cmd!(sh, "virsh dominfo {rm_test_domain}").read()?;
+    let rm_info = cmd!(sh, "env LC_ALL=C virsh dominfo {rm_test_domain}").read()?;
     assert!(
         rm_info.contains("running") || rm_info.contains("idle"),
         "Test VM should be running before rm test"
@@ -338,7 +338,7 @@ fn test_libvirt_comprehensive_workflow() -> TestResult {
     println!("✓ Replaced VM exists with same name");
 
     // Verify it's a fresh VM (should be running)
-    let replaced_info = cmd!(sh, "virsh dominfo {replace_test_domain}").read()?;
+    let replaced_info = cmd!(sh, "env LC_ALL=C virsh dominfo {replace_test_domain}").read()?;
     assert!(
         replaced_info.contains("running") || replaced_info.contains("idle"),
         "Replaced VM should be running"
@@ -491,7 +491,7 @@ fn test_libvirt_run_vm_lifecycle() -> TestResult {
     };
 
     // Verify domain is running (libvirt run starts the domain by default)
-    let info = cmd!(sh, "virsh dominfo {domain_name}").read()?;
+    let info = cmd!(sh, "env LC_ALL=C virsh dominfo {domain_name}").read()?;
     assert!(info.contains("State:"), "Should show domain state");
     assert!(
         info.contains("running") || info.contains("idle"),
@@ -815,7 +815,7 @@ fn test_libvirt_run_transient_vm() -> TestResult {
 
     // Verify domain is transient using virsh dominfo
     println!("Verifying domain is marked as transient...");
-    let dominfo = cmd!(sh, "virsh dominfo {domain_name}").read()?;
+    let dominfo = cmd!(sh, "env LC_ALL=C virsh dominfo {domain_name}").read()?;
     println!("Domain info:\n{}", dominfo);
 
     // Verify "Persistent: no" appears in dominfo
@@ -933,7 +933,7 @@ fn test_libvirt_run_transient_replace() -> TestResult {
     let sh = shell()?;
 
     // Verify domain is transient
-    let dominfo = cmd!(sh, "virsh dominfo {domain_name}").read()?;
+    let dominfo = cmd!(sh, "env LC_ALL=C virsh dominfo {domain_name}").read()?;
     assert!(
         dominfo.contains("Persistent:") && dominfo.contains("no"),
         "Domain should be transient. dominfo: {}",
@@ -951,7 +951,7 @@ fn test_libvirt_run_transient_replace() -> TestResult {
     println!("✓ Successfully replaced transient domain");
 
     // Verify the new domain exists and is transient
-    let dominfo = cmd!(sh, "virsh dominfo {domain_name}").read()?;
+    let dominfo = cmd!(sh, "env LC_ALL=C virsh dominfo {domain_name}").read()?;
     assert!(
         dominfo.contains("Persistent:") && dominfo.contains("no"),
         "Replaced domain should still be transient. dominfo: {}",

--- a/crates/kit/src/domain_list.rs
+++ b/crates/kit/src/domain_list.rs
@@ -89,6 +89,7 @@ impl DomainLister {
     /// Build a virsh command with optional connection URI
     fn virsh_command(&self) -> Command {
         let mut cmd = Command::new("virsh");
+        cmd.env("LC_ALL", "C");
         if let Some(ref uri) = self.connect_uri {
             cmd.arg("-c").arg(uri);
         }

--- a/crates/kit/src/libvirt/mod.rs
+++ b/crates/kit/src/libvirt/mod.rs
@@ -52,6 +52,7 @@ impl LibvirtOptions {
     /// Create a virsh Command with the appropriate connection URI
     pub fn virsh_command(&self) -> std::process::Command {
         let mut cmd = std::process::Command::new("virsh");
+        cmd.env("LC_ALL", "C");
         if let Some(ref uri) = self.connect {
             cmd.arg("-c").arg(uri);
         }

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -29,6 +29,7 @@ const UPDATE_FROM_HOST_TRANSPORT: &str = "containers-storage";
 /// Create a virsh command with optional connection URI
 pub(super) fn virsh_command(connect_uri: Option<&str>) -> Result<std::process::Command> {
     let mut cmd = std::process::Command::new("virsh");
+    cmd.env("LC_ALL", "C");
     if let Some(uri) = connect_uri {
         cmd.arg("-c").arg(uri);
     }


### PR DESCRIPTION
Add `LC_ALL=C` to all `virsh_command()` helper functions so that virsh output is always in English regardless of system locale. Without this, state comparisons like `state == "running"` fail in non-English locales (e.g. Japanese returns "実行中").

Integration tests that call `virsh dominfo` directly are also updated to use `LC_ALL=C`.

Fixes: https://github.com/bootc-dev/bcvk/issues/285