### PR TITLE
packit: Fix EPEL 10 build targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -58,8 +58,9 @@ jobs:
     dist_git_branches: &dist_git_branches
       - fedora-all
       - epel9
-      - epel10.1
+      - epel10
       - epel10.2
+      - epel10.3
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
Replace invalid epel10.1 with epel10, add epel10.3