### PR TITLE
ephemeral run: Fix missing libgcc.so errors in entrypoint

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -839,6 +839,11 @@ fn prepare_run_command_with_temp(
         // (We don't want all of `/` as that would scope in a lot more)
         "/usr:/run/tmproot/usr:ro",
         "-v",
+        // Some host distributions don't have all libraries in /lib or /lib64.
+        // We mount the current ld.so.cache into the tmproot so it matches
+        // library locations in the mounted /usr
+        "/etc/ld.so.cache:/run/tmproot/etc/ld.so.cache:ro",
+        "-v",
         &format!("{}:{}", entrypoint_path, ENTRYPOINT),
         "-v",
         &format!("{self_exe}:/run/selfexe:ro"),


### PR DESCRIPTION
In some host distributions not all system libraries are in the top-level /usr/lib and /usr/lib64 directories. Since we are mounting /usr from the host into the container, we need to account for that by also mounting the local ld.so.cache

Fixes #296

I don't think we need to worry about libraries in `/opt` as the `bcvk` binary has very minimal linking requirements:
```bash
❯ ldd ~/.local/bin/bcvk
        linux-vdso.so.1 (0x00007f499d3de000)
        libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/15/libgcc_s.so.1 (0x00007f499d382000)
        libm.so.6 => /usr/lib64/libm.so.6 (0x00007f499d26d000)
        libc.so.6 => /usr/lib64/libc.so.6 (0x00007f499ca14000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f499d3e0000)
```