### PR TITLE
ephemeral run: propagate kvm group permissions to container

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -822,6 +822,9 @@ fn prepare_run_command_with_temp(
         // Also needed for nested containers
         "--security-opt=seccomp=unconfined",
         "--security-opt=unmask=/proc/*",
+        // Devices like /dev/kvm with group access need those groups propagated to the
+        // container so commands in the container can use them
+        "--group-add=keep-groups",
         // This is a general hardening thing to do when running privileged
         "-v",
         "/sys:/sys:ro",


### PR DESCRIPTION
Mounting /dev/kvm into the container is not sufficient when running through user mode podman on certain distributions. We should keep our host user group in the container to propogate the appropriate permissions for running VMs.

I found this other permission issue when running bcvk on my (non-fedora) setup. I think this is the right approach as permissions to /dev/kvm are controlled by groups on the host as well.