### PR TITLE
Updated to pass virtiofsd to libvirt command

### DIFF
--- a/crates/kit/src/libvirt/base_disks.rs
+++ b/crates/kit/src/libvirt/base_disks.rs
@@ -18,6 +18,7 @@ pub fn find_or_create_base_disk(
     image_digest: &str,
     install_options: &InstallOptions,
     connect_uri: Option<&str>,
+    virtiofsd_binary: Option<&str>,
 ) -> Result<Utf8PathBuf> {
     let metadata = DiskImageMetadata::from(install_options, image_digest, source_image);
     let cache_hash = metadata.compute_cache_hash();
@@ -67,6 +68,7 @@ pub fn find_or_create_base_disk(
         image_digest,
         install_options,
         connect_uri,
+        virtiofsd_binary,
     )?;
 
     Ok(base_disk_path)
@@ -79,6 +81,7 @@ fn create_base_disk(
     image_digest: &str,
     install_options: &InstallOptions,
     connect_uri: Option<&str>,
+    virtiofsd_binary: Option<&str>,
 ) -> Result<()> {
     use crate::run_ephemeral::CommonVmOpts;
     use crate::to_disk::{Format, ToDiskAdditionalOpts, ToDiskOpts};
@@ -116,6 +119,7 @@ fn create_base_disk(
                 memory: crate::common_opts::MemoryOpts {
                     memory: super::LIBVIRT_DEFAULT_MEMORY.to_string(),
                 },
+                virtiofsd_binary: virtiofsd_binary.map(String::from),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/kit/src/libvirt/base_disks_cli.rs
+++ b/crates/kit/src/libvirt/base_disks_cli.rs
@@ -77,6 +77,7 @@ pub fn run_create(
         &image_digest,
         &opts.install_options,
         connect_uri,
+        None,
     )?;
     println!("Created base disk: {path}");
 

--- a/crates/kit/src/libvirt/run.rs
+++ b/crates/kit/src/libvirt/run.rs
@@ -310,6 +310,10 @@ pub struct LibvirtRunOpts {
     #[clap(long = "ignition")]
     pub ignition_config: Option<Utf8PathBuf>,
 
+    /// Path to virtiofsd binary (overrides auto-detection for disk creation)
+    #[clap(long = "virtiofsd", env = "VIRTIOFSD_BIN")]
+    pub virtiofsd_binary: Option<String>,
+
     /// Log virtio console (OS/journald on hvc0) to this file (created if absent)
     #[clap(long = "console-log")]
     pub console_log: Option<Utf8PathBuf>,
@@ -520,6 +524,7 @@ pub fn run(global_opts: &crate::libvirt::LibvirtOptions, mut opts: LibvirtRunOpt
         &image_digest,
         &opts.install,
         connect_uri,
+        opts.virtiofsd_binary.as_deref(),
     )
     .with_context(|| "Failed to find or create base disk")?;
 


### PR DESCRIPTION
I missed this in #266. This adds the `--virtiofsd` command line option to the libvirt command.