### PR TITLE
ephemeral: Fix forcing volatile storage for journald

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -1681,7 +1681,7 @@ StandardOutput=file:/dev/virtio-ports/executestatus
     let mut kernel_cmdline = [
         // This avoids having journald interact with the rootfs
         // at all, which lessens the I/O traffic for virtiofs
-        "systemd.journald.storage=volatile",
+        "systemd.mask=systemd-journal-flush.service",
         // See https://github.com/bootc-dev/bcvk/issues/22
         "selinux=0",
     ]


### PR DESCRIPTION
This replaces the 'systemd.journald.storage=volatile' kernel argument with 'systemd.mask=systemd.journal-flush.service', masking the service responsible for switching to persistent storage.

Commit a6fadf64dcfd44624bb487e2302e929da3b59ff9 introduced the argument 'systemd.journald.storage=volatile' with the intent of keeping the journal in memory for performance. However, this is not supported by current systemd versions, and is simply ignored.

The systemd documentation points out that journald will always use volatile storage initially, and the switch to persistent storage is done automatically by the 'systemd-journal-flush.service' if so configured. Masking this service keeps storage volatile.

Closes: #316