### PR TITLE
ephemeral run: Use correct None datasource for cloud-init

### DIFF
--- a/crates/kit/src/run_ephemeral.rs
+++ b/crates/kit/src/run_ephemeral.rs
@@ -1696,7 +1696,7 @@ StandardOutput=file:/dev/virtio-ports/executestatus
         // We don't provide any cloud-init datasource right now,
         // though in the future it would make sense to do so,
         // and switch over our SSH key injection.
-        kernel_cmdline.push("ds=iid-datasource-none".to_string());
+        kernel_cmdline.push("ds=None".to_string());
     }
 
     // Add Ignition platform kernel argument if Ignition config is specified


### PR DESCRIPTION
While testing local images with cloud-init, I noticed that the application was crashing and not deploying basic config when running the image through bcvk. I traced this down to the qemu command using the incorrect data source. `iid-datasource-none` is the special **instance id** that cloud-init uses for the `None` datasource not the name of the datasource itself.

This PR switches the kernel parameter to `None` so we pass a [valid datasource](https://docs.cloud-init.io/en/latest/reference/datasources/none.html) to cloud-init.

