### PR TITLE
ci: Skip heavy jobs for docs-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+
   build-macos:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -33,6 +48,8 @@ jobs:
         run: cargo test --lib
 
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
 
     steps:
@@ -133,7 +150,8 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-24.04
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -200,7 +218,7 @@ jobs:
   # Accepts 'skipped' as success so that merge_group-only jobs don't block PRs.
   required-checks:
     if: always()
-    needs: [build-macos, build, integration-tests]
+    needs: [changes, build-macos, build, integration-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs


### PR DESCRIPTION
## Summary
- Add a `changes` job using `dorny/paths-filter` to detect docs-only PRs
- Skip `build`, `build-macos`, and `integration-tests` when only `.md` files are changed
- `required-checks` sentinel already accepts `skipped` as success, so branch protection is unaffected

For a docs-only PR, only `changes`, `required-checks`, and DCO will run — saving ~50+ minutes of CI compute.