### PR TITLE
ci: Fix upgrade workflow push rejection

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -101,7 +101,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B "$branch"
           git commit -m "$title"
-          git push --force-with-lease origin "$branch"
+          git push --force origin "$branch"
 
           existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then


### PR DESCRIPTION
The upgrade workflow's `--force-with-lease` push fails with "stale info" when the `automation/upgrade-gh-aw` branch already exists on the remote from a prior run. The workflow only fetches `main` (via actions/checkout), so there is no local remote-tracking ref for the automation branch; `--force-with-lease` cannot verify the remote state and rejects the push.

Switch to `--force`, which is safe here because the branch is exclusively managed by this automation workflow.